### PR TITLE
Groups support for saml-plugin (2nd attempt)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ work
 .classpath
 .project
 .settings
+
+# Intellij IDEA
+.idea
+*.iml

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlGroupAuthority.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlGroupAuthority.java
@@ -1,6 +1,6 @@
 /* Licensed to Jenkins CI under one or more contributor license
 agreements.  See the NOTICE file distributed with this work
-for additional information regarding copyright ownership. 
+for additional information regarding copyright ownership.
 Jenkins CI licenses this file to you under the Apache License,
 Version 2.0 (the "License"); you may not use this file except
 in compliance with the License.  You may obtain a copy of the
@@ -17,27 +17,25 @@ under the License. */
 
 package org.jenkinsci.plugins.saml;
 
-import org.acegisecurity.providers.AbstractAuthenticationToken;
+import org.acegisecurity.GrantedAuthority;
 
-public class SamlAuthenticationToken extends AbstractAuthenticationToken {
+/**
+ * Authority class, represents a group receved in SAML response
+ */
+public class SamlGroupAuthority implements GrantedAuthority {
 
-  private static final long serialVersionUID = 2L;
+  private final String group;
 
-  private final SamlUserDetails userDetails;
-
-  public SamlAuthenticationToken(SamlUserDetails userDetails) {
-    super(userDetails.getAuthorities());
-    this.userDetails = userDetails;
-    this.setDetails(userDetails);
-    this.setAuthenticated(true);
+  public SamlGroupAuthority(String group) {
+    this.group = group;
   }
 
-  public SamlUserDetails getPrincipal() {
-    return userDetails;
+  public String getAuthority() {
+    return this.group;
   }
 
-  public String getCredentials() {
-    return "SAML does not use passwords";
+  @Override
+  public String toString() {
+    return this.group;
   }
-
 }

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -156,7 +156,7 @@ public class SamlSecurityRealm extends SecurityRealm {
     String userFullName = null;
     List<?> names = (List<?>) saml2Profile.getAttribute(this.displayNameAttributeName);
     if (names != null && !names.isEmpty()) {
-      userFullName = (String)names.get(0);
+      userFullName = (String) names.get(0);
     }
 
     // prepare list of groups
@@ -228,6 +228,18 @@ public class SamlSecurityRealm extends SecurityRealm {
 
   public void setIdpMetadata(String idpMetadata) {
     this.idpMetadata = idpMetadata;
+  }
+
+  public String getDisplayNameAttributeName() {
+    return displayNameAttributeName;
+  }
+
+  public String getGroupsAttributeName() {
+    return groupsAttributeName;
+  }
+
+  public Integer getMaximumAuthenticationLifetime() {
+    return maximumAuthenticationLifetime;
   }
 
   @Extension

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlUserDetails.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlUserDetails.java
@@ -22,16 +22,18 @@ import org.acegisecurity.userdetails.UserDetails;
 
 public class SamlUserDetails implements UserDetails {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private final String username;
+  private final GrantedAuthority[] authorities;
   
-  public SamlUserDetails(String username) {
+  public SamlUserDetails(String username, GrantedAuthority[] authorities) {
     this.username = username;
+    this.authorities = authorities;
   }
 
   public GrantedAuthority[] getAuthorities() {
-    return new GrantedAuthority [] {};
+    return authorities;
   }
 
   public String getPassword() {

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlUserDetailsService.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlUserDetailsService.java
@@ -1,0 +1,70 @@
+/* Licensed to Jenkins CI under one or more contributor license
+agreements.  See the NOTICE file distributed with this work
+for additional information regarding copyright ownership.
+Jenkins CI licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.  You may obtain a copy of the
+License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+package org.jenkinsci.plugins.saml;
+
+import hudson.model.User;
+import hudson.security.SecurityRealm;
+import jenkins.model.Jenkins;
+import jenkins.security.LastGrantedAuthoritiesProperty;
+import org.acegisecurity.Authentication;
+import org.acegisecurity.GrantedAuthority;
+import org.acegisecurity.userdetails.UserDetailsService;
+import org.acegisecurity.userdetails.UsernameNotFoundException;
+import org.springframework.dao.DataAccessException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This service is responsible for restoring UserDetails object by userId
+ */
+public class SamlUserDetailsService implements UserDetailsService {
+
+  public SamlUserDetails loadUserByUsername(String username) throws UsernameNotFoundException, DataAccessException {
+
+    // try to obtain user details from current authentication details
+    Authentication auth = Jenkins.getAuthentication();
+    if (auth != null && username.compareTo(auth.getName()) == 0 && auth instanceof SamlAuthenticationToken) {
+      return (SamlUserDetails) auth.getDetails();
+    }
+
+    // try to rebuild authentication details based on data stored in user storage
+    User user = User.get(username);
+    if (user == null) {
+      throw new UsernameNotFoundException(username);
+    }
+
+    List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+    authorities.add(SecurityRealm.AUTHENTICATED_AUTHORITY);
+
+    if (username.compareTo(user.getId()) == 0) {
+      LastGrantedAuthoritiesProperty lastGranted = user.getProperty(LastGrantedAuthoritiesProperty.class);
+      if (lastGranted != null) {
+        for (GrantedAuthority a : lastGranted.getAuthorities()) {
+          if (a != SecurityRealm.AUTHENTICATED_AUTHORITY) {
+            SamlGroupAuthority ga = new SamlGroupAuthority(a.getAuthority());
+            authorities.add(ga);
+          }
+        }
+      }
+    }
+
+    SamlUserDetails userDetails = new SamlUserDetails(user.getId(), authorities.toArray(new GrantedAuthority[0]));
+    return userDetails;
+  }
+}

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -4,16 +4,16 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="SAML Identity Provider Settings" >
-    <f:entry title="IdP Metadata"  field="idpMetadata" help="/plugin/saml/help/metadata.html">
+    <f:entry title="IdP Metadata" field="idpMetadata" help="/plugin/saml/help/metadata.html">
       <f:textarea />
     </f:entry>
-    <f:entry title="Display Name Attribute"  field="displayNameAttributeName" help="/plugin/saml/help/displayNameAttributeName.html">
+    <f:entry title="Display Name Attribute" field="displayNameAttributeName" help="/plugin/saml/help/displayNameAttributeName.html">
       <f:textbox default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" />
     </f:entry>
-    <f:entry title="Group Attribute"  field="groupsAttributeName" help="/plugin/saml/help/groupsAttributeName.html">
+    <f:entry title="Group Attribute" field="groupsAttributeName" help="/plugin/saml/help/groupsAttributeName.html">
       <f:textbox default="http://schemas.xmlsoap.org/claims/Group" />
     </f:entry>
-    <f:entry title="Maximum Authentication Lifetime"  field="maximumAuthenticationLifetime" help="/plugin/saml/help/maximumAuthenticationLifetime.html">
+    <f:entry title="Maximum Authentication Lifetime" field="maximumAuthenticationLifetime" help="/plugin/saml/help/maximumAuthenticationLifetime.html">
       <f:textbox default="86400" />
     </f:entry>
   </f:section>

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -4,8 +4,17 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:section title="SAML Identity Provider Settings" >
-    <f:entry title="IdP Metadata"  field="idpMetadata" help="/plugin/saml-plugin/help/metadata.html">
+    <f:entry title="IdP Metadata"  field="idpMetadata" help="/plugin/saml/help/metadata.html">
       <f:textarea />
+    </f:entry>
+    <f:entry title="Display Name Attribute"  field="displayNameAttributeName" help="/plugin/saml/help/displayNameAttributeName.html">
+      <f:textbox default="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name" />
+    </f:entry>
+    <f:entry title="Group Attribute"  field="groupsAttributeName" help="/plugin/saml/help/groupsAttributeName.html">
+      <f:textbox default="http://schemas.xmlsoap.org/claims/Group" />
+    </f:entry>
+    <f:entry title="Maximum Authentication Lifetime"  field="maximumAuthenticationLifetime" help="/plugin/saml/help/maximumAuthenticationLifetime.html">
+      <f:textbox default="86400" />
     </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help/displayNameAttributeName.html
+++ b/src/main/webapp/help/displayNameAttributeName.html
@@ -1,0 +1,3 @@
+<div>
+  Fill name of display name attribute in SAML response, default is <b>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name</b>
+</div>

--- a/src/main/webapp/help/groupsAttributeName.html
+++ b/src/main/webapp/help/groupsAttributeName.html
@@ -1,0 +1,3 @@
+<div>
+  Fill name of groups attribute in SAML response, default is <b>http://schemas.xmlsoap.org/claims/Group</b>
+</div>

--- a/src/main/webapp/help/maximumAuthenticationLifetime.html
+++ b/src/main/webapp/help/maximumAuthenticationLifetime.html
@@ -1,0 +1,7 @@
+<div>
+  Number of seconds since user was authenticated in IdP while his authentication is considering as active.
+  If you often get "No valid subject assertion found in response" or "Authentication issue instant is too old or in the future"
+  then most probably you need to increase this value.
+  <br/>
+  Default is 24h * 60 min * 60 sec = <b>86400</b>
+</div>

--- a/src/main/webapp/help/metadata.html
+++ b/src/main/webapp/help/metadata.html
@@ -1,3 +1,3 @@
 <div>
-  The Identity Provider metadata file.
+  The Identity Provider metadata file content.
 </div>


### PR DESCRIPTION
There several changes were made
* Groups support added (works in conjunction with [Role-based Authorization Strategy](https://wiki.jenkins-ci.org/display/JENKINS/Role+Strategy+Plugin))
* Added ability to send user full name as a separate claim (user full name will be updated if attribute received and its value is not equal to current value)
* Plugin configuration extended, added settings for 
  * Groups attribute name
  * User full name attribute name
  * Token maximum lifetime (without this setting plugin might begin to fall due to authentication session expiration with certain settings of IdP)
* Added support for showing Groups on user's info page (works only for users with admin rights)