### PR TITLE
More SAML configuration options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
   </parent>
 
   <artifactId>saml</artifactId>
-  <version>0.4-SNAPSHOT</version>
+  <version>(org.jenkins-ci.plugins:saml) 0.4.1</version>
   <packaging>hpi</packaging>
   <name>SAML Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/SAML+Plugin</url>
@@ -38,7 +38,7 @@ under the License.
     <connection>scm:git:git://github.com/jenkinsci/saml-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/saml-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/saml-plugin</url>
-    <tag>saml-0.2</tag>
+    <tag>saml-(org.jenkins-ci.plugins:saml) 0.4.1</tag>
   </scm>
   
   <licenses>

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlEncryptionData.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlEncryptionData.java
@@ -1,3 +1,20 @@
+/* Licensed to Jenkins CI under one or more contributor license
+agreements.  See the NOTICE file distributed with this work
+for additional information regarding copyright ownership.
+Jenkins CI licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.  You may obtain a copy of the
+License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
 package org.jenkinsci.plugins.saml;
 
 import hudson.Util;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlEncryptionData.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlEncryptionData.java
@@ -1,0 +1,34 @@
+package org.jenkinsci.plugins.saml;
+
+import hudson.Util;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Simple immutable data class to hold the optional encryption data section
+ * of the plugin's configuration page
+ */
+public class SamlEncryptionData {
+  private final String keystorePath;
+  private final String keystorePassword;
+  private final String privateKeyPassword;
+
+  @DataBoundConstructor
+  public SamlEncryptionData(String keystorePath, String keystorePassword, String privateKeyPassword) {
+    this.keystorePath = Util.fixEmptyAndTrim(keystorePath);
+    this.keystorePassword = Util.fixEmptyAndTrim(keystorePassword);
+    this.privateKeyPassword = Util.fixEmptyAndTrim(privateKeyPassword);
+  }
+
+  public String getKeystorePath() {
+    return keystorePath;
+  }
+
+  public String getKeystorePassword() {
+    return keystorePassword;
+  }
+
+  public String getPrivateKeyPassword() {
+    return privateKeyPassword;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -255,11 +255,10 @@ public class SamlSecurityRealm extends SecurityRealm {
       if (attribute instanceof List) {
         return (String) ((List<?>)attribute).get(0);
       }
-      LOG.log(Level.SEVERE, "Unable to get username from Saml Profile {0}", saml2Profile);
-      throw new IllegalStateException("Attribute "+usernameAttributeName+" contains no usable username");
-    } else {
-      return saml2Profile.getId();
+      LOG.log(Level.SEVERE, "Unable to get username from attribute {0} value {1}, Saml Profile {2}", new Object[] { usernameAttributeName, attribute, saml2Profile });
+      LOG.log(Level.SEVERE, "Falling back to NameId {0}", saml2Profile.getId());
     }
+    return saml2Profile.getId();
   }
 
   /**

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -78,11 +78,7 @@ public class SamlSecurityRealm extends SecurityRealm {
 
   private String usernameAttributeName;
 
-  private boolean useEncryption = false;
-
-  private String keystorePath;
-  private String keystorePassword;
-  private String privateKeyPassword;
+  private SamlEncryptionData encryptionData = null;
 
   /**
    * Jenkins passes these parameters in when you update the settings.
@@ -91,7 +87,7 @@ public class SamlSecurityRealm extends SecurityRealm {
   @DataBoundConstructor
   public SamlSecurityRealm(String signOnUrl, String idpMetadata,
       String displayNameAttributeName, String groupsAttributeName, Integer maximumAuthenticationLifetime,
-      String usernameAttributeName, SamlEncryptionData useEncryption) {
+      String usernameAttributeName, SamlEncryptionData encryptionData) {
     super();
     this.idpMetadata = Util.fixEmptyAndTrim(idpMetadata);
     this.displayNameAttributeName = DEFAULT_DISPLAY_NAME_ATTRIBUTE_NAME;
@@ -108,10 +104,7 @@ public class SamlSecurityRealm extends SecurityRealm {
       this.maximumAuthenticationLifetime = maximumAuthenticationLifetime;
     }
     this.usernameAttributeName = Util.fixEmptyAndTrim(usernameAttributeName);
-    this.useEncryption = useEncryption != null;
-    this.keystorePath = useEncryption == null ? null : useEncryption.getKeystorePath();
-    this.keystorePassword = useEncryption == null ? null : useEncryption.getKeystorePassword();
-    this.privateKeyPassword = useEncryption == null ? null : useEncryption.getPrivateKeyPassword();
+    this.encryptionData = encryptionData;
   }
 
   @Override
@@ -272,10 +265,10 @@ public class SamlSecurityRealm extends SecurityRealm {
     client.setIdpMetadata(idpMetadata);
     client.setCallbackUrl(getConsumerServiceUrl());
     client.setDestinationBindingType(SAMLConstants.SAML2_REDIRECT_BINDING_URI);
-    if (useEncryption) {
-      client.setKeystorePath(getKeystorePath());
-      client.setKeystorePassword(getKeystorePassword());
-      client.setPrivateKeyPassword(getPrivateKeyPassword());
+    if (encryptionData != null) {
+      client.setKeystorePath(encryptionData.getKeystorePath());
+      client.setKeystorePassword(encryptionData.getKeystorePassword());
+      client.setPrivateKeyPassword(encryptionData.getPrivateKeyPassword());
     }
 
     LOG.fine(client.printClientMetadata());
@@ -323,24 +316,20 @@ public class SamlSecurityRealm extends SecurityRealm {
     return maximumAuthenticationLifetime;
   }
 
-  public boolean isUseEncryption() {
-    return useEncryption;
-  }
-
-  public void setUseEncryption(boolean useEncryption) {
-    this.useEncryption = useEncryption;
+  public SamlEncryptionData getEncryptionData() {
+    return encryptionData;
   }
 
   public String getKeystorePath() {
-    return this.keystorePath;
+    return encryptionData.getKeystorePath();
   }
 
   public String getKeystorePassword() {
-    return this.keystorePassword;
+    return encryptionData.getKeystorePassword();
   }
 
   public String getPrivateKeyPassword() {
-    return this.privateKeyPassword;
+    return encryptionData.getPrivateKeyPassword();
   }
 
   @Extension

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -240,7 +240,7 @@ public class SamlSecurityRealm extends SecurityRealm {
         return (String) ((List<?>)attribute).get(0);
       }
       LOG.log(Level.SEVERE, "Unable to get username from Saml Profile {0}", saml2Profile);
-      throw new Error("Attribute "+usernameAttributeName+" contains no usable username");
+      throw new IllegalStateException("Attribute "+usernameAttributeName+" contains no usable username");
     } else {
       return saml2Profile.getId();
     }

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -337,15 +337,15 @@ public class SamlSecurityRealm extends SecurityRealm {
   }
 
   public String getKeystorePath() {
-    return encryptionData.getKeystorePath();
+    return encryptionData != null ? encryptionData.getKeystorePath() : null;
   }
 
   public String getKeystorePassword() {
-    return encryptionData.getKeystorePassword();
+    return encryptionData != null ? encryptionData.getKeystorePassword() : null;
   }
 
   public String getPrivateKeyPassword() {
-    return encryptionData.getPrivateKeyPassword();
+    return encryptionData != null ? encryptionData.getPrivateKeyPassword() : null;
   }
 
   public String getUsernameCaseConversion() {

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -16,5 +16,30 @@
     <f:entry title="Maximum Authentication Lifetime" field="maximumAuthenticationLifetime" help="/plugin/saml/help/maximumAuthenticationLifetime.html">
       <f:textbox default="86400" />
     </f:entry>
+    <f:entry title="Username Attribute"  field="usernameAttributeName" 
+             help="/plugin/saml/help/usernameAttributeName.html">
+      <f:textbox />
+    </f:entry>
+    
+    <f:optionalBlock field="useEncryption" title="Use Encryption ?" 
+                     help="/plugin/saml/help/encryption.html">
+      <f:entry title="Keystore path"  field="keystorePath" 
+             help="/plugin/saml/help/keystorePath.html">
+        <f:textbox />
+      </f:entry>
+      <f:entry title="Keystore password"  field="keystorePassword" 
+             help="/plugin/saml/help/keystorePassword.html">
+        <f:textbox />
+      </f:entry>
+      <f:entry title="Private Key password"  field="privateKeyPassword" 
+             help="/plugin/saml/help/keyPassword.html">
+        <f:textbox />
+      </f:entry>
+    </f:optionalBlock>
+    
+    <f:entry field="spMetadata" title="SP Metadata">
+      <l:copyButton message="Metadata copied to clipboard" text="${instance.spMetadata}"/>
+        Copy SP Metadata to clipboard to use to configure your IdP.
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -21,18 +21,17 @@
       <f:textbox />
     </f:entry>
     
-    <f:optionalBlock field="useEncryption" title="Use Encryption ?" 
+    <f:optionalBlock title="Use Encryption ?" 
+                     field="encryptionData"
+    checked="${instance.encryptionData != null}"
                      help="/plugin/saml/help/encryption.html">
-      <f:entry title="Keystore path"  field="keystorePath" 
-             help="/plugin/saml/help/keystorePath.html">
+      <f:entry title="Keystore path"  field="keystorePath" help="/plugin/saml/help/keystorePath.html">
         <f:textbox />
       </f:entry>
-      <f:entry title="Keystore password"  field="keystorePassword" 
-             help="/plugin/saml/help/keystorePassword.html">
+      <f:entry title="Keystore password"  field="keystorePassword" help="/plugin/saml/help/keystorePassword.html">
         <f:textbox />
       </f:entry>
-      <f:entry title="Private Key password"  field="privateKeyPassword" 
-             help="/plugin/saml/help/keyPassword.html">
+      <f:entry title="Private Key password"  field="privateKeyPassword" help="/plugin/saml/help/keyPassword.html">
         <f:textbox />
       </f:entry>
     </f:optionalBlock>

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -21,31 +21,30 @@
       <f:textbox />
     </f:entry>
     
-    <f:optionalBlock title="Use Encryption ?" 
-                     field="encryptionData"
-    checked="${instance.encryptionData != null}"
-                     help="/plugin/saml/help/encryption.html">
-      <f:entry title="Keystore path"  field="keystorePath" help="/plugin/saml/help/keystorePath.html">
-        <f:textbox />
-      </f:entry>
-      <f:entry title="Keystore password"  field="keystorePassword" help="/plugin/saml/help/keystorePassword.html">
-        <f:textbox />
-      </f:entry>
-      <f:entry title="Private Key password"  field="privateKeyPassword" help="/plugin/saml/help/keyPassword.html">
-        <f:textbox />
-      </f:entry>
-    </f:optionalBlock>
-    
-    <!-- 
-    <f:entry field="spMetadata" title="SP Metadata">
-      <l:copyButton message="Metadata copied to clipboard" text="${instance.spMetadata}"/>
-        Copy SP Metadata to clipboard to use to configure your IdP.
+    <f:entry> 
+      <table>
+        <f:optionalBlock title="Use Encryption ?" field="encryptionData"
+                         checked="${instance.encryptionData != null}"
+                         help="/plugin/saml/help/encryption.html">
+          <f:entry title="Keystore path"  field="keystorePath" help="/plugin/saml/help/keystorePath.html">
+            <f:textbox />
+          </f:entry>
+          <f:entry title="Keystore password"  field="keystorePassword" help="/plugin/saml/help/keystorePassword.html">
+             <f:textbox />
+           </f:entry>
+           <f:entry title="Private Key password"  field="privateKeyPassword" help="/plugin/saml/help/keyPassword.html">
+             <f:textbox />
+           </f:entry>
+         </f:optionalBlock>
+      </table> 
     </f:entry>
-     -->
-    <f:entry><block>
-      <a href="../securityRealm/metadata">Service Provider Metadata</a> 
-      which may be required to configure your
-      Identity Provider (based on last saved settings).
-    </block></f:entry>
+    
+    <f:entry>
+      <block>
+        <a href="../securityRealm/metadata">Service Provider Metadata</a> 
+        which may be required to configure your Identity Provider 
+        (based on last saved settings).
+      </block>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -36,9 +36,16 @@
       </f:entry>
     </f:optionalBlock>
     
+    <!-- 
     <f:entry field="spMetadata" title="SP Metadata">
       <l:copyButton message="Metadata copied to clipboard" text="${instance.spMetadata}"/>
         Copy SP Metadata to clipboard to use to configure your IdP.
     </f:entry>
+     -->
+    <f:entry><block>
+      <a href="../securityRealm/metadata">Service Provider Metadata</a> 
+      which may be required to configure your
+      Identity Provider (based on last saved settings).
+    </block></f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help/encryption.html
+++ b/src/main/webapp/help/encryption.html
@@ -1,0 +1,17 @@
+<div>
+The SAML standard allows using a key-pair to authenticate and encrypt messages between
+service providers and identity providers.The IdP Metadata entered above contains the 
+IdP's public key, and in order to use encryption for the messages passed from IdP to SP,
+you need to generate a key and enter the details here.  Your IdP may or may not require
+or implement this encryption - check with the IdP administrator if unsure.
+<p>
+The key can be created using the following command:
+<pre>
+$JAVA_HOME/bin/keytool -genkeypair -alias saml-key -keypass &lt;pw1&gt; \
+  -keystore /path/to/saml-key.jks -storepass  &lt;pw2&gt; \
+  -keyalg RSA -keysize 2048 -validity 3650
+  
+</pre>
+where pw1 and pw2 are the key and store passwords respectively.  These passwords need to be entered in the corresponding fields 
+below.  The validity period given above is 10 years, feel free to choose whatever period suits you.
+</div>

--- a/src/main/webapp/help/keyPassword.html
+++ b/src/main/webapp/help/keyPassword.html
@@ -1,0 +1,3 @@
+<div>
+The password used in the <tt>-keypass</tt> argument of <tt>keytool</tt>.
+</div>

--- a/src/main/webapp/help/keystorePassword.html
+++ b/src/main/webapp/help/keystorePassword.html
@@ -1,0 +1,3 @@
+<div>
+The password used in the <tt>-storepass</tt> argument of the <tt>keytool</tt> command.
+</div>

--- a/src/main/webapp/help/keystorePath.html
+++ b/src/main/webapp/help/keystorePath.html
@@ -1,0 +1,3 @@
+<div>
+The path to the keystore file created with the keygen command.
+</div>

--- a/src/main/webapp/help/usernameAttributeName.html
+++ b/src/main/webapp/help/usernameAttributeName.html
@@ -1,0 +1,4 @@
+<div>
+The SAML attribute to use as the username.  
+If blank, we use the nameid provided by the Identity Provider.
+</div>


### PR DESCRIPTION
In order to get the plugin to authenticate nicely with a Shibboleth IdP, I needed a couple of configuration items:
- an SSL key pair.  
- the ability to configure an attribute to be used as the username rather than the nameID.  
It's also very useful to be able to access the SP metadata in order to configure the IdP.  This pull request implements these changes.

The link to access the metadata is a bit clunky - it would be nice if this was a copyButton, but I couldn't see how to make its contents dynamic.