### PR TITLE
[JENKINS-29086] Work-around for handling case sensitivity

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -58,23 +58,26 @@ public class SamlSecurityRealm extends SecurityRealm {
   private static final String DEFAULT_DISPLAY_NAME_ATTRIBUTE_NAME = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name";
   private static final String DEFAULT_GROUPS_ATTRIBUTE_NAME = "http://schemas.xmlsoap.org/claims/Group";
   private static final int DEFAULT_MAXIMUM_AUTHENTICATION_LIFETIME = 24 * 60 * 60; // 24h
+  private static final String DEFAULT_USERNAME_CASE_CONVERSION = "none";
 
   private String idpMetadata;
   private String displayNameAttributeName;
   private String groupsAttributeName;
   private int maximumAuthenticationLifetime;
+  private String usernameCaseConversion;
 
   /**
    * Jenkins passes these parameters in when you update the settings.
    * It does this because of the @DataBoundConstructor
    */
   @DataBoundConstructor
-  public SamlSecurityRealm(String signOnUrl, String idpMetadata, String displayNameAttributeName, String groupsAttributeName, Integer maximumAuthenticationLifetime) {
+  public SamlSecurityRealm(String signOnUrl, String idpMetadata, String displayNameAttributeName, String groupsAttributeName, Integer maximumAuthenticationLifetime, String usernameCaseConversion) {
     super();
     this.idpMetadata = Util.fixEmptyAndTrim(idpMetadata);
     this.displayNameAttributeName = DEFAULT_DISPLAY_NAME_ATTRIBUTE_NAME;
     this.groupsAttributeName = DEFAULT_GROUPS_ATTRIBUTE_NAME;
     this.maximumAuthenticationLifetime = DEFAULT_MAXIMUM_AUTHENTICATION_LIFETIME;
+    this.usernameCaseConversion = DEFAULT_USERNAME_CASE_CONVERSION;
 
     if (displayNameAttributeName != null && !displayNameAttributeName.isEmpty()) {
       this.displayNameAttributeName = displayNameAttributeName;
@@ -85,6 +88,13 @@ public class SamlSecurityRealm extends SecurityRealm {
     if (maximumAuthenticationLifetime != null && maximumAuthenticationLifetime > 0) {
       this.maximumAuthenticationLifetime = maximumAuthenticationLifetime;
     }
+    if (usernameCaseConversion != null && !usernameCaseConversion.isEmpty()) {
+      this.usernameCaseConversion = Util.fixEmptyAndTrim(usernameCaseConversion);;
+    }
+  }
+
+  public SamlSecurityRealm(String signOnUrl, String idpMetadata, String displayNameAttributeName, String groupsAttributeName, Integer maximumAuthenticationLifetime) {
+    this(signOnUrl, idpMetadata, displayNameAttributeName, groupsAttributeName, maximumAuthenticationLifetime, "none");
   }
 
   @Override
@@ -175,8 +185,17 @@ public class SamlSecurityRealm extends SecurityRealm {
       }
     }
 
+    // getId and possibly convert, based on settings
+    String username = saml2Profile.getId();
+    if (this.usernameCaseConversion != null) {
+      if (this.usernameCaseConversion.compareTo("lowercase") == 0) {
+        username = username.toLowerCase();
+      } else if (this.usernameCaseConversion.compareTo("uppercase") == 0) {
+        username = username.toUpperCase();
+      }
+    }
     // create user data
-    SamlUserDetails userDetails = new SamlUserDetails(saml2Profile.getId(), authorities.toArray(new GrantedAuthority[authorities.size()]));
+    SamlUserDetails userDetails = new SamlUserDetails(username, authorities.toArray(new GrantedAuthority[authorities.size()]));
     SamlAuthenticationToken samlAuthToken = new SamlAuthenticationToken(userDetails);
 
     // initialize security context
@@ -240,6 +259,14 @@ public class SamlSecurityRealm extends SecurityRealm {
 
   public Integer getMaximumAuthenticationLifetime() {
     return maximumAuthenticationLifetime;
+  }
+
+  public String getUsernameCaseConversion() {
+    return usernameCaseConversion;
+  }
+
+  public void setUsernameCaseConversion(String usernameCaseConversion) {
+    this.usernameCaseConversion = usernameCaseConversion;
   }
 
   @Extension

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -16,5 +16,12 @@
     <f:entry title="Maximum Authentication Lifetime" field="maximumAuthenticationLifetime" help="/plugin/saml/help/maximumAuthenticationLifetime.html">
       <f:textbox default="86400" />
     </f:entry>
+    <f:entry title="Username Case Conversion" field="usernameCaseConversion" help="/plugin/saml/help/usernameCaseConversion.html">
+      <select name="usernameCaseConversion">
+        <f:option value="none" selected="${instance.usernameCaseConversion == 'none'}">None</f:option>
+        <f:option value="lowercase" selected="${instance.usernameCaseConversion == 'lowercase'}">Lowercase</f:option>
+        <f:option value="uppercase" selected="${instance.usernameCaseConversion == 'uppercase'}">Uppercase</f:option>
+      </select>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/webapp/help/usernameCaseConversion.html
+++ b/src/main/webapp/help/usernameCaseConversion.html
@@ -1,0 +1,12 @@
+<div>
+    The ID returned from SAML is used as the username for Authorization, which
+    is usually case sensitive. To make it easier to match with user definition
+    in the policy, the returned value can be converted.
+    <ul>
+        <li><b>None</b> - will not change return value</li>
+        <li><b>Lowercase</b> - convert to lowercase</li>
+        <li><b>Uppercase</b> - convert to uppercase</li>
+    </ul>
+    <b><u>Caution!</u></b> Be aware of case in Authorization strategy as you
+     may lose access rights if they do no match.
+</div>


### PR DESCRIPTION
[JENKINS-29086] Work-around for handling SAML user id case sensitivity : provide option to convert returned value to a specific case.