### PR TITLE
add CSRF exclusion for the finishLogin url

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlCrumbExclusion.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlCrumbExclusion.java
@@ -22,9 +22,9 @@ public class SamlCrumbExclusion extends CrumbExclusion {
             throws IOException, ServletException {
         String pathInfo = request.getPathInfo();
         if(shouldExclude(pathInfo)) {
+            chain.doFilter(request, response);
             return true;
         }
-        chain.doFilter(request, response);
         return false;
     }
 
@@ -36,7 +36,7 @@ public class SamlCrumbExclusion extends CrumbExclusion {
             LOG.fine("SamlCrumbExclusion.shouldExclude excluding '" + pathInfo + "'");
             return true;
         } else {
-            LOG.fine("SamlCrumbExclusion.shouldExclude keeping '" + pathInfo + "'");
+            LOG.finer("SamlCrumbExclusion.shouldExclude keeping '" + pathInfo + "'");
             return false;
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlCrumbExclusion.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlCrumbExclusion.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.saml;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.security.SecurityRealm;
+import hudson.security.csrf.CrumbExclusion;
+
+@Extension
+public class SamlCrumbExclusion extends CrumbExclusion {
+    private static final Logger LOG = Logger.getLogger(SamlCrumbExclusion.class.getName());
+
+    @Override
+    public boolean process(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String pathInfo = request.getPathInfo();
+        if(shouldExclude(pathInfo)) {
+            return true;
+        }
+        chain.doFilter(request, response);
+        return false;
+    }
+
+    private static boolean shouldExclude(String pathInfo) {
+        if(pathInfo == null) {
+            return false;
+        }
+        if(pathInfo.indexOf(SamlSecurityRealm.CONSUMER_SERVICE_URL_PATH) == 1) {
+            LOG.fine("SamlCrumbExclusion.shouldExclude excluding '" + pathInfo + "'");
+            return true;
+        } else {
+            LOG.fine("SamlCrumbExclusion.shouldExclude keeping '" + pathInfo + "'");
+            return false;
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -51,10 +51,11 @@ import java.util.logging.Logger;
  * Uses Stapler (stapler.kohsuke.org) to bind methods to URLs.
  */
 public class SamlSecurityRealm extends SecurityRealm {
+  public static final String CONSUMER_SERVICE_URL_PATH = "securityRealm/finishLogin";
+
 
   private static final Logger LOG = Logger.getLogger(SamlSecurityRealm.class.getName());
   private static final String REFERER_ATTRIBUTE = SamlSecurityRealm.class.getName() + ".referer";
-  private static final String CONSUMER_SERVICE_URL_PATH = "securityRealm/finishLogin";
   private static final String DEFAULT_DISPLAY_NAME_ATTRIBUTE_NAME = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name";
   private static final String DEFAULT_GROUPS_ATTRIBUTE_NAME = "http://schemas.xmlsoap.org/claims/Group";
   private static final int DEFAULT_MAXIMUM_AUTHENTICATION_LIFETIME = 24 * 60 * 60; // 24h


### PR DESCRIPTION
It's not possible to use the SAML plugin along with the CSRF protection built in to Jenkins.  This is because the auth redirect that goes back to Jenkins doesn't contain the protection crumb.  Since it would be difficult to force an auth, it makes sense to remove the CSRF protection from that endpoint in particular.  That is what this pull request does.