### PR TITLE
Generate client metadata xml and add doc to access it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -39,6 +39,7 @@ import org.pac4j.saml.client.Saml2Client;
 import org.pac4j.saml.credentials.Saml2Credentials;
 import org.pac4j.saml.profile.Saml2Profile;
 
+import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -221,6 +222,15 @@ public class SamlSecurityRealm extends SecurityRealm {
     String referer = (String) request.getSession().getAttribute(REFERER_ATTRIBUTE);
     String redirectUrl = referer != null ? referer : baseUrl();
     return HttpResponses.redirectTo(redirectUrl);
+  }
+
+  public HttpResponse doMetadata(StaplerRequest request, StaplerResponse response) {
+    return new HttpResponse() {
+      public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
+        rsp.setContentType("text/xml;charset=UTF-8");
+        rsp.getWriter().println(newClient().printClientMetadata());
+      }
+    };
   }
 
   private Saml2Client newClient() {

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -23,5 +23,8 @@
         <f:option value="uppercase" selected="${instance.usernameCaseConversion == 'uppercase'}">Uppercase</f:option>
       </select>
     </f:entry>
+    <f:block>
+        <p>${%blurb(app.rootUrl)}</p>
+    </f:block>
   </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.properties
@@ -1,0 +1,2 @@
+blurb=\
+    Once the IdP Metadata is applied / saved, access client metadata <a href="{0}securityRealm/metadata">here</a>


### PR DESCRIPTION
I exposed a method to allow users to download the generated metadata that can then be used to configure the relay.  I think it may need some more work so that it can set the claims though (at least for ADFS).