### PR TITLE
Fix maximum authentication lifetime setting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -285,9 +285,10 @@ public class SamlSecurityRealm extends SecurityRealm {
       client.setKeystorePassword(encryptionData.getKeystorePassword());
       client.setPrivateKeyPassword(encryptionData.getPrivateKeyPassword());
     }
-
-    LOG.fine(client.printClientMetadata());
     client.setMaximumAuthenticationLifetime(this.maximumAuthenticationLifetime);
+    if (LOG.isLoggable(Level.FINE)) {
+      LOG.fine(client.printClientMetadata());
+    }
     return client;
   }
 


### PR DESCRIPTION
`maximumAuthenticationLifetime` setting had no effect, because client is initialised in `printClientMetadata` method and after init changing `maximumAuthenticationLifetime` has no effect.