### PR TITLE
[JENKINS-38971] Add support SAML ForceAuthn, AuthnContextClassRef, custom EntityId, and session timeout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
   </parent>
 
   <artifactId>saml</artifactId>
-  <version>0.13-SNAPSHOT</version>
+  <version>0.13</version>
   <packaging>hpi</packaging>
   <name>SAML Plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/SAML+Plugin</url>
@@ -52,6 +52,10 @@ under the License.
     <developer>
       <id>benmccann</id>
       <name>Ben McCann</name>
+    </developer>
+    <developer>
+      <id>swl</id>
+      <name>Scotty Logan</name>
     </developer>
   </developers>
 

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
@@ -1,0 +1,58 @@
+/* Licensed to Jenkins CI under one or more contributor license
+agreements.  See the NOTICE file distributed with this work
+for additional information regarding copyright ownership.
+Jenkins CI licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.  You may obtain a copy of the
+License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License. */
+
+package org.jenkinsci.plugins.saml;
+
+import hudson.Util;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Simple immutable data class to hold the optional advanced configuration data section
+ * of the plugin's configuration page
+ */
+public class SamlAdvancedConfiguration {
+  private final Boolean forceAuthn;
+  private final String  authnContextClassRef;
+  private final String  spEntityId;
+  private final Integer maximumSessionLifetime;
+  
+  @DataBoundConstructor
+  public SamlAdvancedConfiguration(Boolean forceAuthn, String authnContextClassRef, String spEntityId, Integer maximumSessionLifetime) {
+    this.forceAuthn = (forceAuthn != null) ? forceAuthn : false;
+    this.authnContextClassRef = Util.fixEmptyAndTrim(authnContextClassRef);
+    this.spEntityId = Util.fixEmptyAndTrim(spEntityId);
+    this.maximumSessionLifetime = maximumSessionLifetime;
+  }
+
+  public Boolean getForceAuthn() {
+    return forceAuthn;
+  }
+
+  public String getAuthnContextClassRef() {
+    return authnContextClassRef;
+  }
+
+  public String getSpEntityId() {
+    return spEntityId;
+  }
+
+  public Integer getMaximumSessionLifetime() {
+    return maximumSessionLifetime;
+  }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlAuthenticationToken.java
@@ -17,22 +17,44 @@ under the License. */
 
 package org.jenkinsci.plugins.saml;
 
+import org.kohsuke.stapler.Stapler;
+
 import org.acegisecurity.providers.AbstractAuthenticationToken;
+import org.acegisecurity.context.SecurityContextHolder;
 
 public class SamlAuthenticationToken extends AbstractAuthenticationToken {
 
   private static final long serialVersionUID = 2L;
 
   private final SamlUserDetails userDetails;
+  private final long expirationTime;
 
-  public SamlAuthenticationToken(SamlUserDetails userDetails) {
+  public SamlAuthenticationToken(SamlUserDetails userDetails, long expirationTime) {
     super(userDetails.getAuthorities());
     this.userDetails = userDetails;
     this.setDetails(userDetails);
     this.setAuthenticated(true);
+    this.expirationTime = expirationTime;
+  }
+
+  public SamlAuthenticationToken(SamlUserDetails userDetails) {
+    this(userDetails, 0);
   }
 
   public SamlUserDetails getPrincipal() {
+    // check if session should have expired
+    if (expirationTime > 0 && System.currentTimeMillis() > expirationTime) {
+      // sometimes getCurrentRequest() returns null
+      if (Stapler.getCurrentRequest() != null) {
+        // terminate the current session
+        this.setAuthenticated(false);
+        if (Stapler.getCurrentRequest().getSession() != null) {
+          Stapler.getCurrentRequest().getSession().invalidate();
+        }
+        SecurityContextHolder.clearContext();
+      }
+    }
+
     return userDetails;
   }
 

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -27,7 +27,32 @@
         <f:option value="uppercase" selected="${instance.usernameCaseConversion == 'uppercase'}">Uppercase</f:option>
       </select>
     </f:entry>
-    
+
+    <f:entry>
+      <table>
+        <f:optionalBlock title="Advanced Configuration ?" field="advancedConfiguration"
+                         checked="${instance.advancedConfiguration != null}">
+
+          <f:entry title="Force Authentication?" field="forceAuthn" help="/plugin/saml/help/forceAuthn.html">
+            <f:checkbox />
+          </f:entry>
+
+          <f:entry title="Authentication Context" field="authnContextClassRef" help="/plugin/saml/help/authnContextClassRef.html">
+            <f:textbox />
+          </f:entry>
+
+          <f:entry title="SP Entity ID" field="spEntityId" help="/plugin/saml/help/spEntityId.html">
+            <f:textbox />
+          </f:entry>
+
+          <f:entry title="Maximum Session Lifetime" field="maximumSessionLifetime" help="/plugin/saml/help/maximumSessionLifetime.html">
+            <f:textbox default="86400" />
+          </f:entry>
+
+        </f:optionalBlock>
+      </table>
+    </f:entry>
+
     <f:entry> 
       <table>
         <f:optionalBlock title="Use Encryption ?" field="encryptionData"

--- a/src/main/webapp/help/authnContextClassRef.html
+++ b/src/main/webapp/help/authnContextClassRef.html
@@ -1,0 +1,5 @@
+<div>
+  If this field is not empty, request that the SAML IdP uses a specific
+  authentication context, rather than its default. Check with the IdP
+  administrators to find out which authentication contexts are available.
+</div>

--- a/src/main/webapp/help/forceAuthn.html
+++ b/src/main/webapp/help/forceAuthn.html
@@ -1,0 +1,3 @@
+<div>
+  Whether to request the SAML IdP to force (re)authentication of the user, rather than allowing an existing session with the IdP to be reused.  Off by default.
+</div>

--- a/src/main/webapp/help/spEntityId.html
+++ b/src/main/webapp/help/spEntityId.html
@@ -1,0 +1,4 @@
+<div>
+  If this field is not empty, it overrides the default Entity ID for this Service Provider.
+  Service Provider Entity IDs are usually a URL, like <tt>http://jenkins.example.org/</tt>.
+</div>


### PR DESCRIPTION
This is the pull request mentioned in JENKINS-38971.

We have a deployment where we to use SAML ForceAuthn to force logins at our IdP, and AuthnContextClassRef to override the default authentication mechanism and force multi-factor authentication; we also need the sessions on Jenkins to be shorter than those on our IdP.
