### PR TITLE
[JENKINS-47850] log SAMLResponse on encoding errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ Caused by: java.lang.IllegalArgumentException: Illegal base64 character d
     at java.util.Base64$Decoder.decode(Base64.java:549)
     at org.jenkinsci.plugins.saml.SamlSecurityRealm.doFinishLogin(SamlSecurityRealm.java:258)
 ```
+

--- a/README.md
+++ b/README.md
@@ -68,10 +68,21 @@ org.pac4j.saml.exceptions.SAMLException: Identity provider has no single sign on
 **Identity provider does not support encryption settings**
 
 * Downgrade to 0.14 version, if it works, then enable encryption on that version to be sure that this is the issue
+* Check the JDK version does not have issues like this [JDK-8176043](https://bugs.openjdk.java.net/browse/JDK-8176043)
 
 ```
-2017-10-18 19:56:28.987+0000 [id=23]    WARNING o.e.j.s.h.ContextHandler$Context#log: Error while serving https://jenkins.example.com/securityRealm/finishLogin
+2017-10-18 20:26:49.568+0000 [id=1296]	WARNING	o.j.p.s.SuppressionFilter#reportError: Request processing failed. URI=/securityRealm/finishLogin clientIP=192.168.1.100 ErrorID=b04ec3d5-8fbe-4961-88f2-187f47649000
 org.opensaml.messaging.decoder.MessageDecodingException: This message decoder only supports the HTTP POST method
+	at org.pac4j.saml.transport.Pac4jHTTPPostDecoder.doDecode(Pac4jHTTPPostDecoder.java:57)
+	at org.opensaml.messaging.decoder.AbstractMessageDecoder.decode(AbstractMessageDecoder.java:58)
+	at org.pac4j.saml.sso.impl.SAML2WebSSOMessageReceiver.receiveMessage(SAML2WebSSOMessageReceiver.java:40)
+Caused: org.pac4j.saml.exceptions.SAMLException: Error decoding saml message
+	at org.pac4j.saml.sso.impl.SAML2WebSSOMessageReceiver.receiveMessage(SAML2WebSSOMessageReceiver.java:43)
+	at org.pac4j.saml.sso.impl.SAML2WebSSOProfileHandler.receive(SAML2WebSSOProfileHandler.java:35)
+	at org.pac4j.saml.client.SAML2Client.retrieveCredentials(SAML2Client.java:225)
+	at org.pac4j.saml.client.SAML2Client.retrieveCredentials(SAML2Client.java:60)
+	at org.pac4j.core.client.IndirectClient.getCredentials(IndirectClient.java:106)
+	at org.jenkinsci.plugins.saml.SamlProfileWrapper.process(SamlProfileWrapper.java:53)
 ```
 
 ```

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -309,7 +309,7 @@ public class SamlSecurityRealm extends SecurityRealm {
     }
 
     /**
-     *
+     * Tries to log the content of the SAMLResponse even it is not valid.
      * @param request Request received in doFinishLogin, it should be a SAMLResponse.
      */
     private void logSamlResponse(StaplerRequest request) {

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -32,6 +32,7 @@ import org.acegisecurity.*;
 import org.acegisecurity.context.SecurityContextHolder;
 import org.acegisecurity.userdetails.UsernameNotFoundException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.*;
 import org.pac4j.core.client.RedirectAction;
@@ -43,6 +44,7 @@ import javax.annotation.Nonnull;
 import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -55,6 +57,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static org.apache.commons.codec.binary.Base64.*;
 import static org.opensaml.saml.common.xml.SAMLConstants.SAML2_REDIRECT_BINDING_URI;
 
 /**
@@ -254,13 +257,7 @@ public class SamlSecurityRealm extends SecurityRealm {
      */
     public HttpResponse doFinishLogin(final StaplerRequest request, final StaplerResponse response) {
         LOG.finer("SamlSecurityRealm.doFinishLogin called");
-        if(LOG.isLoggable(Level.FINEST)){
-            try {
-                LOG.finest("SAMLResponse XML:" + new String(Base64.getDecoder().decode(request.getParameter("SAMLResponse")),"UTF-8"));
-            } catch (UnsupportedEncodingException e) {
-                LOG.finest("No UTF-8 SAMLResponse XML");
-            }
-        }
+        logSamlResponse(request);
         boolean saveUser = false;
 
         SAML2Profile saml2Profile = new SamlProfileWrapper(getSamlPluginConfig(), request, response).get();
@@ -309,6 +306,30 @@ public class SamlSecurityRealm extends SecurityRealm {
         String referer = (String) request.getSession().getAttribute(REFERER_ATTRIBUTE);
         String redirectUrl = referer != null ? referer : baseUrl();
         return HttpResponses.redirectTo(redirectUrl);
+    }
+
+    /**
+     *
+     * @param request Request received in doFinishLogin, it should be a SAMLResponse.
+     */
+    private void logSamlResponse(StaplerRequest request) {
+        if(LOG.isLoggable(Level.FINEST)){
+            try {
+                String samlResponse = request.getParameter("SAMLResponse");
+                if(isBase64(samlResponse)) {
+                    LOG.finest("SAMLResponse XML:" + new String(decodeBase64(samlResponse), request.getCharacterEncoding()));
+                } else {
+                    LOG.finest("SAMLResponse XML:" + samlResponse);
+                }
+            } catch (Exception e) {
+                LOG.finest("No UTF-8 SAMLResponse XML");
+                try(InputStream in = request.getInputStream()) {
+                    LOG.finest(IOUtils.toString(in, request.getCharacterEncoding()));
+                } catch (IOException e1) {
+                    LOG.finest("Was not possible to read the request");
+                }
+            }
+        }
     }
 
     private String baseUrl() {


### PR DESCRIPTION
[JENKINS-47850](https://issues.jenkins-ci.org/browse/JENKINS-47850)

* Logs the SAMLResponse even it is not valid
* Protect against [JDK-8176043](https://bugs.openjdk.java.net/browse/JDK-8176043)

```
Caused by: java.lang.IllegalArgumentException: Illegal base64 character d
    at java.util.Base64$Decoder.decode0(Base64.java:714)
    at java.util.Base64$Decoder.decode(Base64.java:526)
    at java.util.Base64$Decoder.decode(Base64.java:549)
    at org.jenkinsci.plugins.saml.SamlSecurityRealm.doFinishLogin(SamlSecurityRealm.java:258)
```

@reviewbybees 