### PR TITLE
[JENKINS-49532] autogenerated keystore should not be kept in temp directory

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/BundleKeyStore.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/BundleKeyStore.java
@@ -78,7 +78,8 @@ public class BundleKeyStore {
         try {
 
             if (keystore == null) {
-                keystore = File.createTempFile("saml-jenkins-keystore-", ".jks");
+                String jenkinsHome = jenkins.model.Jenkins.getInstance().getRootDir().getPath();
+                keystore = java.nio.file.Paths.get(jenkinsHome, "saml-jenkins-keystore.jks").toFile();
                 keystorePath = "file:" + keystore.getPath();
             }
 


### PR DESCRIPTION
[JENKINS-49532](https://issues.jenkins-ci.org/browse/JENKINS-49532)

@reviewbybees 