### PR TITLE
improve session lifetime help

### DIFF
--- a/src/main/webapp/help/maximumSessionLifetime.html
+++ b/src/main/webapp/help/maximumSessionLifetime.html
@@ -1,6 +1,7 @@
 <div>
     you could set the sessions on Jenkins to be shorter than those on your IdP.
     Number of seconds since user was authenticated in IdP while his authentication is considering as active.
+    Note that the authentication lifetime is limited by Jenkins HTTP session timeout.
     <br/>
     Default is 24h * 60 min * 60 sec = <b>86400</b>
 </div>


### PR DESCRIPTION
Jenkins uses jetty which has a default http session timeout of 30min (https://stackoverflow.com/q/26407541). Should mention in the help that this is relevant to saml auth.