### PR TITLE
[JENKINS-55175] - Use Mockito from Plugin POM to support testing with Java 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,8 @@
-buildPlugin(jenkinsVersions: [null, '2.107.2'])
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "8", jenkins: "2.150.1", javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: "2.150.1", javaLevel: "8" ],
+  [ platform: "linux", jdk: "11", jenkins: "2.155", javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: "2.155", javaLevel: "8" ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.8</version>
+    <version>3.30-20181213.131016-1</version>
   </parent>
 
   <artifactId>saml</artifactId>
@@ -140,7 +140,6 @@ under the License.
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.8.9</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-55175

Requires https://github.com/jenkinsci/plugin-pom/pull/141 to be released first

@jenkinsci/java11-support 
