### PR TITLE
[JENKINS-59097] Possibility to set NameIDPolicy in the SAML Request 

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
@@ -115,7 +115,7 @@ public abstract class OpenSAMLWrapper<T> {
             config.setKeystoreAlias(KS.getKsPkAlias());
             config.setForceSignRedirectBindingAuthnRequest(false);
         }
-
+        config.setNameIdPolicyFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified");
         config.setMaximumAuthenticationLifetime(samlPluginConfig.getMaximumAuthenticationLifetime());
 
         if (samlPluginConfig.getAdvancedConfiguration() != null) {

--- a/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
@@ -115,7 +115,7 @@ public abstract class OpenSAMLWrapper<T> {
             config.setKeystoreAlias(KS.getKsPkAlias());
             config.setForceSignRedirectBindingAuthnRequest(false);
         }
-        config.setNameIdPolicyFormat("urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified");
+
         config.setMaximumAuthenticationLifetime(samlPluginConfig.getMaximumAuthenticationLifetime());
 
         if (samlPluginConfig.getAdvancedConfiguration() != null) {
@@ -134,6 +134,10 @@ public abstract class OpenSAMLWrapper<T> {
             if (samlPluginConfig.getAuthnContextClassRef() != null) {
                 config.setAuthnContextClassRef(samlPluginConfig.getAuthnContextClassRef());
                 config.setComparisonType("exact");
+            }
+
+            if(samlPluginConfig.getNameIdPolicyFormat() != null) {
+                config.setNameIdPolicyFormat(samlPluginConfig.getNameIdPolicyFormat());
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
@@ -37,7 +37,7 @@ public class SamlAdvancedConfiguration extends AbstractDescribableImpl<SamlAdvan
     private final Boolean forceAuthn;
     private final String authnContextClassRef;
     private final String spEntityId;
-
+    private final String nameIdPolicyFormat;
     /**
      * @deprecated not used anymore
      */
@@ -48,10 +48,12 @@ public class SamlAdvancedConfiguration extends AbstractDescribableImpl<SamlAdvan
     public SamlAdvancedConfiguration(Boolean forceAuthn,
                                      String authnContextClassRef,
                                      String spEntityId,
+                                     String nameIdPolicyFormat,
                                      Integer maximumSessionLifetime) {
         this.forceAuthn = (forceAuthn != null) ? forceAuthn : false;
         this.authnContextClassRef = Util.fixEmptyAndTrim(authnContextClassRef);
         this.spEntityId = Util.fixEmptyAndTrim(spEntityId);
+        this.nameIdPolicyFormat = Util.fixEmptyAndTrim(nameIdPolicyFormat);
     }
 
     public Boolean getForceAuthn() {
@@ -66,12 +68,17 @@ public class SamlAdvancedConfiguration extends AbstractDescribableImpl<SamlAdvan
         return spEntityId;
     }
 
+    public String getNameIdPolicyFormat() {
+        return nameIdPolicyFormat;
+    }
+
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("SamlAdvancedConfiguration{");
         sb.append("forceAuthn=").append(getForceAuthn());
         sb.append(", authnContextClassRef='").append(StringUtils.defaultIfBlank(getAuthnContextClassRef(), "none")).append('\'');
         sb.append(", spEntityId='").append(StringUtils.defaultIfBlank(getSpEntityId(), "none")).append('\'');
+        sb.append(", nameIdPolicyFormat='").append(StringUtils.defaultIfBlank(getNameIdPolicyFormat(), "none")).append('\'');
         sb.append('}');
         return sb.toString();
     }
@@ -99,6 +106,10 @@ public class SamlAdvancedConfiguration extends AbstractDescribableImpl<SamlAdvan
 
         public FormValidation doCheckSpEntityId(@org.kohsuke.stapler.QueryParameter String spEntityId) {
             return SamlFormValidation.checkStringFormat(spEntityId);
+        }
+
+        public FormValidation doCheckNameIdPolicyFormat(@org.kohsuke.stapler.QueryParameter String nameIdPolicyFormat) {
+            return SamlFormValidation.checkStringFormat(nameIdPolicyFormat);
         }
 
         public FormValidation doCheckMaximumSessionLifetime(@org.kohsuke.stapler.QueryParameter String maximumSessionLifetime) {

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlPluginConfig.java
@@ -91,6 +91,10 @@ public class SamlPluginConfig {
         return getAdvancedConfiguration() != null ? getAdvancedConfiguration().getSpEntityId() : null;
     }
 
+    public String getNameIdPolicyFormat() {
+        return getAdvancedConfiguration() != null ? getAdvancedConfiguration().getNameIdPolicyFormat() : null;
+    }
+
     public SamlEncryptionData getEncryptionData() {
         return encryptionData;
     }

--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration/config.jelly
@@ -11,4 +11,7 @@
     <f:entry title="SP Entity ID" field="spEntityId" help="/plugin/saml/help/spEntityId.html">
         <f:textbox/>
     </f:entry>
+    <f:entry title="NameIDPolicy Format" field="nameIdPolicyFormat" help="/plugin/saml/help/nameIdPolicyFormat.html">
+            <f:textbox/>
+        </f:entry>
 </j:jelly>

--- a/src/main/webapp/help/nameIdPolicyFormat.html
+++ b/src/main/webapp/help/nameIdPolicyFormat.html
@@ -1,0 +1,3 @@
+<div>
+    Set your NameIDPolicy in the AuthnRequest, for example: <code>urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified</code>
+</div>

--- a/src/test/java/org/jenkinsci/plugins/saml/SamlSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/saml/SamlSecurityRealmTest.java
@@ -198,9 +198,9 @@ public class SamlSecurityRealmTest {
                 samlSecurityRealm.getAdvancedConfiguration());
         assertEquals(samlPluginConfig.toString().equals(samlSecurityRealm.getSamlPluginConfig().toString()), true);
 
-        assertEquals(new SamlAdvancedConfiguration(null,null,null, null).toString().contains("SamlAdvancedConfiguration"),true);
-        assertEquals(new SamlAdvancedConfiguration(true,null,null, null).toString().contains("SamlAdvancedConfiguration"),true);
-        assertEquals(new SamlAdvancedConfiguration(true,"","", 1).toString().contains("SamlAdvancedConfiguration"),true);
+        assertEquals(new SamlAdvancedConfiguration(null,null,null, null, null).toString().contains("SamlAdvancedConfiguration"),true);
+        assertEquals(new SamlAdvancedConfiguration(true,null,null, null, null).toString().contains("SamlAdvancedConfiguration"),true);
+        assertEquals(new SamlAdvancedConfiguration(true,"","", "", 1).toString().contains("SamlAdvancedConfiguration"),true);
 
         SamlGroupAuthority authority = new SamlGroupAuthority("role001");
         assertEquals(authority.toString().equals("role001"),true);


### PR DESCRIPTION
This was needed to work with ADFS (v2).
Adding the NameIDPolicy in the AuthnRequest sent from the SP to the Idp.