### PR TITLE
[JENKINS-59126] Add compatibility test with JCasC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@ under the License.
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.107.3</jenkins.version>
     <java.level>8</java.level>
+    <jcasc.version>1.29</jcasc.version>
   </properties>
 
   <licenses>
@@ -148,6 +149,20 @@ under the License.
       <groupId>org.hamcrest</groupId>
       <artifactId>java-hamcrest</artifactId>
       <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- JCasC compatibility -->
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins</groupId>
+      <artifactId>configuration-as-code</artifactId>
+      <version>${jcasc.version}</version>
+      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/jenkinsci/plugins/saml/SamlJCasCCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/saml/SamlJCasCCompatibilityTest.java
@@ -9,6 +9,7 @@ import org.jvnet.hudson.test.RestartableJenkinsRule;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -17,48 +18,48 @@ public class SamlJCasCCompatibilityTest extends RoundTripAbstractTest {
     @Override
     protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
         final SecurityRealm realm = restartableJenkinsRule.j.jenkins.getSecurityRealm();
-        assertTrue("The Security Realm should not be null", realm != null);
-        assertTrue("The Security Realm should be SamlSecurityRealm", realm instanceof SamlSecurityRealm);
+        assertNotNull(realm);
+        assertTrue(realm instanceof SamlSecurityRealm);
 
         final SamlSecurityRealm samlRealm = (SamlSecurityRealm)realm;
         // Simple attributes
-        assertEquals(String.format("Wrong Display Name Attribute Name value. Expected %s but retrieved %s", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", samlRealm.getDisplayNameAttributeName()), "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", samlRealm.getDisplayNameAttributeName());
-        assertEquals(String.format("Wrong Group Attribute value. Expected %s but retrieved %s", "http://schemas.xmlsoap.org/claims/Group", samlRealm.getGroupsAttributeName()), "http://schemas.xmlsoap.org/claims/Group", samlRealm.getGroupsAttributeName());
-        assertEquals(String.format("Wrong Maximum Authentication Lifetime value. Expected %d but retrieved %d", 86400, samlRealm.getMaximumAuthenticationLifetime()), 86400, samlRealm.getMaximumAuthenticationLifetime().longValue());
-        assertEquals(String.format("Wrong Email Attribute value. Expected %s but retrieved %s", "fake@mail.com", samlRealm.getEmailAttributeName()), "fake@mail.com", samlRealm.getEmailAttributeName());
-        assertEquals(String.format("Wrong Username Attribute  value. Expected %s but retrieved %s", "urn:mace:dir:attribute-def:uid", samlRealm.getUsernameAttributeName()), "urn:mace:dir:attribute-def:uid", samlRealm.getUsernameAttributeName());
-        assertEquals(String.format("Wrong Username Case Conversion value. Expected %s but retrieved %s", "none", samlRealm.getUsernameCaseConversion()), "none", samlRealm.getUsernameCaseConversion());
-        assertEquals(String.format("Wrong Logout URL value. Expected %s but retrieved %s", "http://fake.logout.url", samlRealm.getLogoutUrl()), "http://fake.logout.url", samlRealm.getLogoutUrl());
-        assertEquals(String.format("Wrong Data Binding Method value. Expected %s but retrieved %s", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", samlRealm.getBinding()), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", samlRealm.getBinding());
+        assertEquals("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", samlRealm.getDisplayNameAttributeName());
+        assertEquals("http://schemas.xmlsoap.org/claims/Group", samlRealm.getGroupsAttributeName());
+        assertEquals(86400, samlRealm.getMaximumAuthenticationLifetime().longValue());
+        assertEquals("fake@mail.com", samlRealm.getEmailAttributeName());
+        assertEquals("urn:mace:dir:attribute-def:uid", samlRealm.getUsernameAttributeName());
+        assertEquals("none", samlRealm.getUsernameCaseConversion());
+        assertEquals("http://fake.logout.url", samlRealm.getLogoutUrl());
+        assertEquals("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", samlRealm.getBinding());
 
         // Complex attributes
         final SamlAdvancedConfiguration advanced = samlRealm.getAdvancedConfiguration();
-        assertTrue("The Advanced Configuration should not be null", advanced != null);
-        assertTrue("Wrong Force Authentication value in Advanced Configuration. It should be forced", advanced.getForceAuthn());
-        assertEquals(String.format("Wrong Authentication Context value in Advanced Configuration. Expected %s but retrieved %s", "anotherContext", advanced.getAuthnContextClassRef()),"anotherContext", advanced.getAuthnContextClassRef());
-        assertEquals(String.format("Wrong SSP Entity ID value in Advanced Configuration. Expected %s but retrieved %s", "mySpEntityId", advanced.getSpEntityId()), "mySpEntityId", advanced.getSpEntityId());
+        assertNotNull(advanced);
+        assertTrue(advanced.getForceAuthn());
+        assertEquals("anotherContext", advanced.getAuthnContextClassRef());
+        assertEquals("mySpEntityId", advanced.getSpEntityId());
 
         final SamlEncryptionData encryption = samlRealm.getEncryptionData();
-        assertTrue("The Encryption Configuration should not be null", encryption != null);
-        assertEquals(String.format("Wrong Keystore Path value in Encryption Configuration. Expected %s but retrieved %s", "/home/jdk/keystore", encryption.getKeystorePath()),"/home/jdk/keystore", encryption.getKeystorePath());
-        assertEquals(String.format("Wrong Private Key Alias value in Encryption Configuration. Expected %s but retrieved %s", "privatealias", encryption.getPrivateKeyAlias()),"privatealias", encryption.getPrivateKeyAlias());
+        assertNotNull(encryption);
+        assertEquals("/home/jdk/keystore", encryption.getKeystorePath());
+        assertEquals("privatealias", encryption.getPrivateKeyAlias());
 
         final IdpMetadataConfiguration metadata = samlRealm.getIdpMetadataConfiguration();
-        assertTrue("The IdP Metadata should not be null", metadata != null);
-        assertEquals(String.format("Wrong IdP Metadata URL value in IdP Metadata. Expected %s but retrieved %s", "http://fake.ldP.metadata.url", metadata.getUrl()), "http://fake.ldP.metadata.url", metadata.getUrl());
-        assertEquals(String.format("Wrong Refresh Period value in IdP Metadata. Expected %d but retrieved %d", 2, metadata.getPeriod()), 2, metadata.getPeriod().longValue());
-        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"simpleSAMLphpIdpHosted\">"));
-        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:ContactPerson contactType=\"technical\">"));
-        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:GivenName>Administrator</md:GivenName>"));
-        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:EmailAddress>dublindev@glgroup.com</md:EmailAddress>"));
+        assertNotNull(metadata);
+        assertEquals("http://fake.ldP.metadata.url", metadata.getUrl());
+        assertEquals(2, metadata.getPeriod().longValue());
+        assertThat(metadata.getXml(), containsString("<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"simpleSAMLphpIdpHosted\">"));
+        assertThat(metadata.getXml(), containsString("<md:ContactPerson contactType=\"technical\">"));
+        assertThat(metadata.getXml(), containsString("<md:GivenName>Administrator</md:GivenName>"));
+        assertThat(metadata.getXml(), containsString("<md:EmailAddress>dublindev@glgroup.com</md:EmailAddress>"));
 
         final List<AttributeEntry> customAttributes = samlRealm.getSamlCustomAttributes();
-        assertTrue("The Custom Attributes should not be null", customAttributes != null);
-        assertEquals(String.format("There should be 2 custom attributes but got %d", customAttributes.size()), 2, customAttributes.size());
-        assertEquals(String.format("Wrong Attribute Name value in the first custom attribute. Expected %s but retrieved %s", "attribute1", ((Attribute)customAttributes.get(0)).getName()),"attribute1", ((Attribute)customAttributes.get(0)).getName());
-        assertEquals(String.format("Wrong Display Name in user properties value in the first custom attribute. Expected %s but retrieved %s", "display1", ((Attribute)customAttributes.get(0)).getDisplayName()), "display1", ((Attribute)customAttributes.get(0)).getDisplayName());
-        assertEquals(String.format("Wrong Attribute Name value in the second custom attribute. Expected %s but retrieved %s", "attribute2", ((Attribute)customAttributes.get(1)).getName()),"attribute2", ((Attribute)customAttributes.get(1)).getName());
-        assertEquals(String.format("Wrong Display Name in user properties value in the second custom attribute. Expected %s but retrieved %s", "display2", ((Attribute)customAttributes.get(1)).getDisplayName()), "display2", ((Attribute)customAttributes.get(1)).getDisplayName());
+        assertNotNull(customAttributes);
+        assertEquals(2, customAttributes.size());
+        assertEquals("attribute1", ((Attribute)customAttributes.get(0)).getName());
+        assertEquals("display1", ((Attribute)customAttributes.get(0)).getDisplayName());
+        assertEquals("attribute2", ((Attribute)customAttributes.get(1)).getName());
+        assertEquals("display2", ((Attribute)customAttributes.get(1)).getDisplayName());
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/saml/SamlJCasCCompatibilityTest.java
+++ b/src/test/java/org/jenkinsci/plugins/saml/SamlJCasCCompatibilityTest.java
@@ -1,0 +1,68 @@
+package org.jenkinsci.plugins.saml;
+
+import hudson.security.SecurityRealm;
+import io.jenkins.plugins.casc.misc.RoundTripAbstractTest;
+import org.jenkinsci.plugins.saml.conf.Attribute;
+import org.jenkinsci.plugins.saml.conf.AttributeEntry;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.containsString;
+
+public class SamlJCasCCompatibilityTest extends RoundTripAbstractTest {
+    @Override
+    protected void assertConfiguredAsExpected(RestartableJenkinsRule restartableJenkinsRule, String s) {
+        final SecurityRealm realm = restartableJenkinsRule.j.jenkins.getSecurityRealm();
+        assertTrue("The Security Realm should not be null", realm != null);
+        assertTrue("The Security Realm should be SamlSecurityRealm", realm instanceof SamlSecurityRealm);
+
+        final SamlSecurityRealm samlRealm = (SamlSecurityRealm)realm;
+        // Simple attributes
+        assertEquals(String.format("Wrong Display Name Attribute Name value. Expected %s but retrieved %s", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", samlRealm.getDisplayNameAttributeName()), "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name", samlRealm.getDisplayNameAttributeName());
+        assertEquals(String.format("Wrong Group Attribute value. Expected %s but retrieved %s", "http://schemas.xmlsoap.org/claims/Group", samlRealm.getGroupsAttributeName()), "http://schemas.xmlsoap.org/claims/Group", samlRealm.getGroupsAttributeName());
+        assertEquals(String.format("Wrong Maximum Authentication Lifetime value. Expected %d but retrieved %d", 86400, samlRealm.getMaximumAuthenticationLifetime()), 86400, samlRealm.getMaximumAuthenticationLifetime().longValue());
+        assertEquals(String.format("Wrong Email Attribute value. Expected %s but retrieved %s", "fake@mail.com", samlRealm.getEmailAttributeName()), "fake@mail.com", samlRealm.getEmailAttributeName());
+        assertEquals(String.format("Wrong Username Attribute  value. Expected %s but retrieved %s", "urn:mace:dir:attribute-def:uid", samlRealm.getUsernameAttributeName()), "urn:mace:dir:attribute-def:uid", samlRealm.getUsernameAttributeName());
+        assertEquals(String.format("Wrong Username Case Conversion value. Expected %s but retrieved %s", "none", samlRealm.getUsernameCaseConversion()), "none", samlRealm.getUsernameCaseConversion());
+        assertEquals(String.format("Wrong Logout URL value. Expected %s but retrieved %s", "http://fake.logout.url", samlRealm.getLogoutUrl()), "http://fake.logout.url", samlRealm.getLogoutUrl());
+        assertEquals(String.format("Wrong Data Binding Method value. Expected %s but retrieved %s", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", samlRealm.getBinding()), "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect", samlRealm.getBinding());
+
+        // Complex attributes
+        final SamlAdvancedConfiguration advanced = samlRealm.getAdvancedConfiguration();
+        assertTrue("The Advanced Configuration should not be null", advanced != null);
+        assertTrue("Wrong Force Authentication value in Advanced Configuration. It should be forced", advanced.getForceAuthn());
+        assertEquals(String.format("Wrong Authentication Context value in Advanced Configuration. Expected %s but retrieved %s", "anotherContext", advanced.getAuthnContextClassRef()),"anotherContext", advanced.getAuthnContextClassRef());
+        assertEquals(String.format("Wrong SSP Entity ID value in Advanced Configuration. Expected %s but retrieved %s", "mySpEntityId", advanced.getSpEntityId()), "mySpEntityId", advanced.getSpEntityId());
+
+        final SamlEncryptionData encryption = samlRealm.getEncryptionData();
+        assertTrue("The Encryption Configuration should not be null", encryption != null);
+        assertEquals(String.format("Wrong Keystore Path value in Encryption Configuration. Expected %s but retrieved %s", "/home/jdk/keystore", encryption.getKeystorePath()),"/home/jdk/keystore", encryption.getKeystorePath());
+        assertEquals(String.format("Wrong Private Key Alias value in Encryption Configuration. Expected %s but retrieved %s", "privatealias", encryption.getPrivateKeyAlias()),"privatealias", encryption.getPrivateKeyAlias());
+
+        final IdpMetadataConfiguration metadata = samlRealm.getIdpMetadataConfiguration();
+        assertTrue("The IdP Metadata should not be null", metadata != null);
+        assertEquals(String.format("Wrong IdP Metadata URL value in IdP Metadata. Expected %s but retrieved %s", "http://fake.ldP.metadata.url", metadata.getUrl()), "http://fake.ldP.metadata.url", metadata.getUrl());
+        assertEquals(String.format("Wrong Refresh Period value in IdP Metadata. Expected %d but retrieved %d", 2, metadata.getPeriod()), 2, metadata.getPeriod().longValue());
+        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"simpleSAMLphpIdpHosted\">"));
+        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:ContactPerson contactType=\"technical\">"));
+        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:GivenName>Administrator</md:GivenName>"));
+        assertThat("Wrong Metadata value in IdP Metadata", metadata.getXml(), containsString("<md:EmailAddress>dublindev@glgroup.com</md:EmailAddress>"));
+
+        final List<AttributeEntry> customAttributes = samlRealm.getSamlCustomAttributes();
+        assertTrue("The Custom Attributes should not be null", customAttributes != null);
+        assertEquals(String.format("There should be 2 custom attributes but got %d", customAttributes.size()), 2, customAttributes.size());
+        assertEquals(String.format("Wrong Attribute Name value in the first custom attribute. Expected %s but retrieved %s", "attribute1", ((Attribute)customAttributes.get(0)).getName()),"attribute1", ((Attribute)customAttributes.get(0)).getName());
+        assertEquals(String.format("Wrong Display Name in user properties value in the first custom attribute. Expected %s but retrieved %s", "display1", ((Attribute)customAttributes.get(0)).getDisplayName()), "display1", ((Attribute)customAttributes.get(0)).getDisplayName());
+        assertEquals(String.format("Wrong Attribute Name value in the second custom attribute. Expected %s but retrieved %s", "attribute2", ((Attribute)customAttributes.get(1)).getName()),"attribute2", ((Attribute)customAttributes.get(1)).getName());
+        assertEquals(String.format("Wrong Display Name in user properties value in the second custom attribute. Expected %s but retrieved %s", "display2", ((Attribute)customAttributes.get(1)).getDisplayName()), "display2", ((Attribute)customAttributes.get(1)).getDisplayName());
+    }
+
+    @Override
+    protected String stringInLogExpected() {
+        return "Setting class org.jenkinsci.plugins.saml.SamlSecurityRealm. emailAttributeName = fake@mail.com";
+    }
+}

--- a/src/test/resources/org/jenkinsci/plugins/saml/configuration-as-code.yaml
+++ b/src/test/resources/org/jenkinsci/plugins/saml/configuration-as-code.yaml
@@ -1,0 +1,58 @@
+jenkins:
+  securityRealm:
+    saml:
+      advancedConfiguration:
+        authnContextClassRef: "anotherContext"
+        forceAuthn: true
+        spEntityId: "mySpEntityId"
+      binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+      displayNameAttributeName: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+      emailAttributeName: "fake@mail.com"
+      encryptionData:
+        forceSignRedirectBindingAuthnRequest: true
+        keystorePassword: "{AQAAABAAAAAQW05cASi2RE3zzrl9xskAhhuYAamBbQe0k5Bk9lkDd80=}"
+        keystorePath: "/home/jdk/keystore"
+        privateKeyAlias: "privatealias"
+        privateKeyPassword: "{AQAAABAAAAAQ40qxDUu7fjfmHst04RrBvBm24Om5JBeKAYLnA/9OXZk=}"
+      groupsAttributeName: "http://schemas.xmlsoap.org/claims/Group"
+      idpMetadataConfiguration:
+        period: 2
+        url: "http://fake.ldP.metadata.url"
+        xml: |-
+          <?xml version="1.0"?>
+          <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="simpleSAMLphpIdpHosted">
+            <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+              <md:KeyDescriptor use="signing">
+                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                  <ds:X509Data>
+                    <ds:X509Certificate>MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=</ds:X509Certificate>
+                  </ds:X509Data>
+                </ds:KeyInfo>
+              </md:KeyDescriptor>
+              <md:KeyDescriptor use="encryption">
+                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                  <ds:X509Data>
+                    <ds:X509Certificate>MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=</ds:X509Certificate>
+                  </ds:X509Data>
+                </ds:KeyInfo>
+              </md:KeyDescriptor>
+              <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://192.168.99.100:58080/simplesaml/saml2/idp/SingleLogoutService.php"/>
+              <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
+              <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://192.168.99.100:58080/simplesaml/saml2/idp/SSOService.php"/>
+            </md:IDPSSODescriptor>
+            <md:ContactPerson contactType="technical">
+              <md:GivenName>Administrator</md:GivenName>
+              <md:EmailAddress>dublindev@glgroup.com</md:EmailAddress>
+            </md:ContactPerson>
+          </md:EntityDescriptor>
+      logoutUrl: "http://fake.logout.url"
+      maximumAuthenticationLifetime: 86400
+      samlCustomAttributes:
+        - attribute:
+            displayName: "display1"
+            name: "attribute1"
+        - attribute:
+            displayName: "display2"
+            name: "attribute2"
+      usernameAttributeName: "urn:mace:dir:attribute-def:uid"
+      usernameCaseConversion: "none"


### PR DESCRIPTION
See [JENKINS-59126](https://issues.jenkins-ci.org/browse/JENKINS-59126)

So far, _saml-plugin_ is compatible with JCasC and can be both exported and configured using that plugin. This PR adds a compatibility test so any future incompatibility can be detected in advance in such way as other plugins:

- [ant-plugin](https://github.com/jenkinsci/ant-plugin/blob/master/src/test/java/hudson/tasks/AntJCasCCompatibilityTest.java)
- [git-plugin](https://github.com/jenkinsci/git-plugin/blob/master/src/test/java/jenkins/plugins/git/GitJCasCCompatibilityTest.java)
- [antisamy-markup-formatter-plugin](https://github.com/jenkinsci/antisamy-markup-formatter-plugin/blob/master/src/test/java/hudson/markup/JCasCCompatibilityTest.java)

See below the config.xml configured by UI, the jenkins.yaml with the export using JCasC and the config.xml configured importing the yaml file into a clean instalation (without having configured SAML). All the data to get it done has been extracted from already existing tests.

### Excerpt from a sample config.xml configured by UI
```
<securityRealm class="org.jenkinsci.plugins.saml.SamlSecurityRealm" plugin="saml@1.1.2">
    <displayNameAttributeName>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name</displayNameAttributeName>
    <groupsAttributeName>http://schemas.xmlsoap.org/claims/Group</groupsAttributeName>
    <maximumAuthenticationLifetime>86400</maximumAuthenticationLifetime>
    <emailAttributeName>fake@mail.com</emailAttributeName>
    <usernameCaseConversion>none</usernameCaseConversion>
    <usernameAttributeName>urn:mace:dir:attribute-def:uid</usernameAttributeName>
    <logoutUrl>http://fake.logout.url</logoutUrl>
    <binding>urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect</binding>
    <encryptionData>
      <keystorePath>/home/jdk/keystore</keystorePath>
      <keystorePasswordSecret>{AQAAABAAAAAQs2RlHlrNu7wkrWRLWPVbr7or5R+HK+38oAlmL5KX/Po=}</keystorePasswordSecret>
      <privateKeyPasswordSecret>{AQAAABAAAAAQEolv7+T8E9ZFIOEezxtdpZq+rjaF4ImwDl5peaSosWs=}</privateKeyPasswordSecret>
      <privateKeyAlias>privatealias</privateKeyAlias>
      <forceSignRedirectBindingAuthnRequest>true</forceSignRedirectBindingAuthnRequest>
    </encryptionData>
    <advancedConfiguration>
      <forceAuthn>true</forceAuthn>
      <authnContextClassRef>anotherContext</authnContextClassRef>
      <spEntityId>mySpEntityId</spEntityId>
    </advancedConfiguration>
    <idpMetadataConfiguration>
      <xml>&lt;?xml version=&quot;1.0&quot;?&gt;
&lt;md:EntityDescriptor xmlns:md=&quot;urn:oasis:names:tc:SAML:2.0:metadata&quot; xmlns:ds=&quot;http://www.w3.org/2000/09/xmldsig#&quot; entityID=&quot;simpleSAMLphpIdpHosted&quot;&gt;
  &lt;md:IDPSSODescriptor protocolSupportEnumeration=&quot;urn:oasis:names:tc:SAML:2.0:protocol&quot;&gt;
    &lt;md:KeyDescriptor use=&quot;signing&quot;&gt;
      &lt;ds:KeyInfo xmlns:ds=&quot;http://www.w3.org/2000/09/xmldsig#&quot;&gt;
        &lt;ds:X509Data&gt;
          &lt;ds:X509Certificate&gt;MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=&lt;/ds:X509Certificate&gt;
        &lt;/ds:X509Data&gt;
      &lt;/ds:KeyInfo&gt;
    &lt;/md:KeyDescriptor&gt;
    &lt;md:KeyDescriptor use=&quot;encryption&quot;&gt;
      &lt;ds:KeyInfo xmlns:ds=&quot;http://www.w3.org/2000/09/xmldsig#&quot;&gt;
        &lt;ds:X509Data&gt;
          &lt;ds:X509Certificate&gt;MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=&lt;/ds:X509Certificate&gt;
        &lt;/ds:X509Data&gt;
      &lt;/ds:KeyInfo&gt;
    &lt;/md:KeyDescriptor&gt;
    &lt;md:SingleLogoutService Binding=&quot;urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect&quot; Location=&quot;http://192.168.99.100:58080/simplesaml/saml2/idp/SingleLogoutService.php&quot;/&gt;
    &lt;md:NameIDFormat&gt;urn:oasis:names:tc:SAML:2.0:nameid-format:transient&lt;/md:NameIDFormat&gt;
    &lt;md:SingleSignOnService Binding=&quot;urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect&quot; Location=&quot;http://192.168.99.100:58080/simplesaml/saml2/idp/SSOService.php&quot;/&gt;
  &lt;/md:IDPSSODescriptor&gt;
  &lt;md:ContactPerson contactType=&quot;technical&quot;&gt;
    &lt;md:GivenName&gt;Administrator&lt;/md:GivenName&gt;
    &lt;md:EmailAddress&gt;dublindev@glgroup.com&lt;/md:EmailAddress&gt;
  &lt;/md:ContactPerson&gt;
&lt;/md:EntityDescriptor&gt;</xml>
      <url>http://fake.ldP.metadata.url</url>
      <period>2</period>
    </idpMetadataConfiguration>
    <samlCustomAttributes>
      <org.jenkinsci.plugins.saml.conf.Attribute>
        <name>attribute 1</name>
        <displayName>display 1</displayName>
      </org.jenkinsci.plugins.saml.conf.Attribute>
      <org.jenkinsci.plugins.saml.conf.Attribute>
        <name>attribute 2</name>
        <displayName>display 2</displayName>
      </org.jenkinsci.plugins.saml.conf.Attribute>
    </samlCustomAttributes>
  </securityRealm>
```

### Excerpt from a config.xml configured with JCasC
```
<securityRealm class="org.jenkinsci.plugins.saml.SamlSecurityRealm" plugin="saml@1.1.2">
    <displayNameAttributeName>http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name</displayNameAttributeName>
    <groupsAttributeName>http://schemas.xmlsoap.org/claims/Group</groupsAttributeName>
    <maximumAuthenticationLifetime>86400</maximumAuthenticationLifetime>
    <emailAttributeName>fake@mail.com</emailAttributeName>
    <usernameCaseConversion>none</usernameCaseConversion>
    <usernameAttributeName>urn:mace:dir:attribute-def:uid</usernameAttributeName>
    <logoutUrl>http://fake.logout.url</logoutUrl>
    <binding>urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect</binding>
    <encryptionData>
      <keystorePath>/home/jdk/keystore</keystorePath>
      <keystorePasswordSecret>{AQAAABAAAAAQs2RlHlrNu7wkrWRLWPVbr7or5R+HK+38oAlmL5KX/Po=}</keystorePasswordSecret>
      <privateKeyPasswordSecret>{AQAAABAAAAAQEolv7+T8E9ZFIOEezxtdpZq+rjaF4ImwDl5peaSosWs=}</privateKeyPasswordSecret>
      <privateKeyAlias>privatealias</privateKeyAlias>
      <forceSignRedirectBindingAuthnRequest>true</forceSignRedirectBindingAuthnRequest>
    </encryptionData>
    <advancedConfiguration>
      <forceAuthn>true</forceAuthn>
      <authnContextClassRef>anotherContext</authnContextClassRef>
      <spEntityId>mySpEntityId</spEntityId>
    </advancedConfiguration>
    <idpMetadataConfiguration>
      <xml>&lt;?xml version=&quot;1.0&quot;?&gt;
&lt;md:EntityDescriptor xmlns:md=&quot;urn:oasis:names:tc:SAML:2.0:metadata&quot; xmlns:ds=&quot;http://www.w3.org/2000/09/xmldsig#&quot; entityID=&quot;simpleSAMLphpIdpHosted&quot;&gt;
  &lt;md:IDPSSODescriptor protocolSupportEnumeration=&quot;urn:oasis:names:tc:SAML:2.0:protocol&quot;&gt;
    &lt;md:KeyDescriptor use=&quot;signing&quot;&gt;
      &lt;ds:KeyInfo xmlns:ds=&quot;http://www.w3.org/2000/09/xmldsig#&quot;&gt;
        &lt;ds:X509Data&gt;
          &lt;ds:X509Certificate&gt;MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=&lt;/ds:X509Certificate&gt;
        &lt;/ds:X509Data&gt;
      &lt;/ds:KeyInfo&gt;
    &lt;/md:KeyDescriptor&gt;
    &lt;md:KeyDescriptor use=&quot;encryption&quot;&gt;
      &lt;ds:KeyInfo xmlns:ds=&quot;http://www.w3.org/2000/09/xmldsig#&quot;&gt;
        &lt;ds:X509Data&gt;
          &lt;ds:X509Certificate&gt;MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=&lt;/ds:X509Certificate&gt;
        &lt;/ds:X509Data&gt;
      &lt;/ds:KeyInfo&gt;
    &lt;/md:KeyDescriptor&gt;
    &lt;md:SingleLogoutService Binding=&quot;urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect&quot; Location=&quot;http://192.168.99.100:58080/simplesaml/saml2/idp/SingleLogoutService.php&quot;/&gt;
    &lt;md:NameIDFormat&gt;urn:oasis:names:tc:SAML:2.0:nameid-format:transient&lt;/md:NameIDFormat&gt;
    &lt;md:SingleSignOnService Binding=&quot;urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect&quot; Location=&quot;http://192.168.99.100:58080/simplesaml/saml2/idp/SSOService.php&quot;/&gt;
  &lt;/md:IDPSSODescriptor&gt;
  &lt;md:ContactPerson contactType=&quot;technical&quot;&gt;
    &lt;md:GivenName&gt;Administrator&lt;/md:GivenName&gt;
    &lt;md:EmailAddress&gt;dublindev@glgroup.com&lt;/md:EmailAddress&gt;
  &lt;/md:ContactPerson&gt;
&lt;/md:EntityDescriptor&gt;</xml>
      <url>http://fake.ldP.metadata.url</url>
      <period>2</period>
    </idpMetadataConfiguration>
    <samlCustomAttributes>
      <org.jenkinsci.plugins.saml.conf.Attribute>
        <name>attribute 1</name>
        <displayName>display 1</displayName>
      </org.jenkinsci.plugins.saml.conf.Attribute>
      <org.jenkinsci.plugins.saml.conf.Attribute>
        <name>attribute 2</name>
        <displayName>display 2</displayName>
      </org.jenkinsci.plugins.saml.conf.Attribute>
    </samlCustomAttributes>
  </securityRealm>
```

### Excerpt from jenkins.yaml exported by JCasC and later imported in a clean instance
```
jenkins:
  securityRealm:
    saml:
      advancedConfiguration:
        authnContextClassRef: "anotherContext"
        forceAuthn: true
        spEntityId: "mySpEntityId"
      binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
      displayNameAttributeName: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
      emailAttributeName: "fake@mail.com"
      encryptionData:
        forceSignRedirectBindingAuthnRequest: true
        keystorePassword: "{AQAAABAAAAAQs2RlHlrNu7wkrWRLWPVbr7or5R+HK+38oAlmL5KX/Po=}"
        keystorePath: "/home/jdk/keystore"
        privateKeyAlias: "privatealias"
        privateKeyPassword: "{AQAAABAAAAAQEolv7+T8E9ZFIOEezxtdpZq+rjaF4ImwDl5peaSosWs=}"
      groupsAttributeName: "http://schemas.xmlsoap.org/claims/Group"
      idpMetadataConfiguration:
        period: 2
        url: "http://fake.ldP.metadata.url"
        xml: |-
          <?xml version="1.0"?>
          <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" entityID="simpleSAMLphpIdpHosted">
            <md:IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
              <md:KeyDescriptor use="signing">
                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
                  <ds:X509Data>
                    <ds:X509Certificate>MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=</ds:X509Certificate>
                  </ds:X509Data>
                </ds:KeyInfo>
              </md:KeyDescriptor>
              <md:KeyDescriptor use="encryption">
                <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
                  <ds:X509Data>
                    <ds:X509Certificate>MIIDtTCCAp2gAwIBAgIJAINeCx9sdNHLMA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwHhcNMTYxMTE4MTcyMDAwWhcNMjYxMTE4MTcyMDAwWjBFMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAkbkG/8UGDrqNUCpCn3NXGQqG0+oHXeU+htHXash6zhcYb45se+lRoISgh6vSlc2NOVVuNBf1lrFziKdi5dvnbLKkxL+0SOww3ZP3VttzrE1Fk7ZXCU4o2x5P7Mt3UXyx4Ik10OCEybhdR57EuGXnc14QCOn3OH/d05bzlh8WpVz5FrqPmhpGwsqtqwC4CAHWszbklA9nc6jeNwGqeb6JUez6OihBxSUoHulyjqsnNYGobmmK85DSxmZe8uT8SO3xHRvn6UYYjxckh2XzR/NVh+sDEZjCZLP1J9py2MT4HFBh252SNDbboh0BC3/qCmwK/IS0fMy2W/08g6RJwGlkVQIDAQABo4GnMIGkMB0GA1UdDgQWBBQIUCMMqKSMB7npenjd6uiK4QsLljB1BgNVHSMEbjBsgBQIUCMMqKSMB7npenjd6uiK4QsLlqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAINeCx9sdNHLMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAFppKlxgIeYGgM5AnC+1d2btAel0tIX8zYWnDnCcjKyEJTM8ztGq/fXz8KMhTbmtD1ITD5DGaAyEPCRpSoLXybXtp/OeVMO+hNjh+RGV8jSzjSnbMY/cWClYz+v+oW9+CxVN+k6KYPHRrSSDtmOyUVg7NcQnJoPXV7Ch9UKW4oCkom9+rcRYjCTFBq9jsj38OcwRIWLqGa+E8QG26H+MT24B7bSxWakajwjYCFdcI5QA9vEL5q5ZBd8rt2yzlAXZ2bMOynq7gvkg2Yt5uzWeGu0IBonbceEwwQ9Eyid0x4mNg9s8F3e9oMRpvsnA3gm60znRR1jEomFOIVpJoIjU9es=</ds:X509Certificate>
                  </ds:X509Data>
                </ds:KeyInfo>
              </md:KeyDescriptor>
              <md:SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://192.168.99.100:58080/simplesaml/saml2/idp/SingleLogoutService.php"/>
              <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:transient</md:NameIDFormat>
              <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://192.168.99.100:58080/simplesaml/saml2/idp/SSOService.php"/>
            </md:IDPSSODescriptor>
            <md:ContactPerson contactType="technical">
              <md:GivenName>Administrator</md:GivenName>
              <md:EmailAddress>dublindev@glgroup.com</md:EmailAddress>
            </md:ContactPerson>
          </md:EntityDescriptor>
      logoutUrl: "http://fake.logout.url"
      maximumAuthenticationLifetime: 86400
      samlCustomAttributes:
      - attribute:
          displayName: "display 1"
          name: "attribute 1"
      - attribute:
          displayName: "display 2"
          name: "attribute 2"
      usernameAttributeName: "urn:mace:dir:attribute-def:uid"
      usernameCaseConversion: "none"
```

**Desired reviewers:**
@kuisathaverat as maintainer
@varyvol @MRamonLeon @alecharp @oleg-nenashev @rsandell 
CC @casz @timja since it's JCasC related