### PR TITLE
[JENKINS-59172] Use GitHub as a source of the plugin's documentation on plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ under the License.
   <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>SAML Plugin</name>
-  <url>https://wiki.jenkins.io/display/JENKINS/SAML+Plugin</url>
+  <url>https://github.com/jenkinsci/saml-plugin</url>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/saml-plugin.git</connection>


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/jenkinsci-dev/VSdfVMDIW-A
In the case of the plugin the GitHub documentation is a bit more informative ATM.
Maybe we should add a screenshot to the README to have all content from Wiki there.