### PR TITLE
Enable Release Drafter for the repository

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,6 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+# Semantic versioning is used d=for this plugin: https://semver.org/
+version-template: $MAJOR.$MINOR.$PATCH
+tag-template: ssh-slaves-$NEXT_PATCH_VERSION
+name-template: $NEXT_PATCH_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 Changelog
 -------------------
+
+| WARNING: Changelogs have been moved to [GitHub Releases](https://github.com/jenkinsci/saml-plugin/releases) |
+| --- |
+
+ ### Newer versions
+
+ * See [GitHub Releases](https://github.com/jenkinsci/saml-plugin/releases)
+ 
 * 1.1.2 (Dec 16 2018)
   * [JENKINS-55216](https://issues.jenkins-ci.org/browse/JENKINS-55216) Remove MaximumSessionLifetime setting
   * [JENKINS-55205](https://issues.jenkins-ci.org/browse/JENKINS-55205) Review findbugs error with some OS+JDK

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A SAML 2.0 Plugin for the Jenkins Continuous Integration server
 
 Changelog
 -------------------
-[Changelog](CHANGELOG.md)
+* For 1.1.3 and newer versions, see [GitHub Releases](https://github.com/jenkinsci/saml-plugin/releases)
+* For previous versions, see [this file](./CHANGELOG.md)
 
 Configure
 -------------------


### PR DESCRIPTION
Just a quality of life improvement which simplifies changelog management in the plugin.

