### PR TITLE
[JENKINS-60742] Bump core to 2.176.1 version and bump plugin dependecies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ def buildConfiguration = [
   [ platform: "linux",   jdk: "11", jenkins: lts, javaLevel: "8" ],
   [ platform: "windows", jdk: "11", jenkins: lts, javaLevel: "8" ],
   // Also build on recent weekly
-  [ platform: "linux",   jdk: "11", jenkins: weekly, javaLevel: "8" ],
-  [ platform: "windows", jdk: "11", jenkins: weekly, javaLevel: "8" ]
+//  [ platform: "linux",   jdk: "11", jenkins: weekly, javaLevel: "8" ],
+//  [ platform: "windows", jdk: "11", jenkins: weekly, javaLevel: "8" ]
 ]
 
 buildPlugin(configurations: buildConfiguration)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,15 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+//def buildConfiguration = buildPlugin.recommendedConfigurations()
+
+def lts = "2.176.1"
+def weekly = "2.199"
+def buildConfiguration = [
+  [ platform: "linux",   jdk: "8", jenkins: lts, javaLevel: "8" ],
+  [ platform: "windows", jdk: "8", jenkins: lts, javaLevel: "8" ],
+  [ platform: "linux",   jdk: "11", jenkins: lts, javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: lts, javaLevel: "8" ],
+  // Also build on recent weekly
+  [ platform: "linux",   jdk: "11", jenkins: weekly, javaLevel: "8" ],
+  [ platform: "windows", jdk: "11", jenkins: weekly, javaLevel: "8" ]
+]
+
+buildPlugin(configurations: buildConfiguration)

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.49</version>
+    <version>3.55</version>
   </parent>
 
   <artifactId>saml</artifactId>
@@ -44,7 +44,7 @@ under the License.
   <properties>
     <revision>1.1.5</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.164.1</jenkins.version>
+    <jenkins.version>2.176.1</jenkins.version>
     <java.level>8</java.level>
     <jcasc.version>1.30</jcasc.version>
   </properties>
@@ -121,7 +121,7 @@ under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.24</version>
+      <version>1.29</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
See [JENKINS-60742](https://issues.jenkins-ci.org/browse/JENKINS-60742).

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

