### PR TITLE
Upgrade to use jcasc test harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@ under the License.
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.176.1</jenkins.version>
     <java.level>8</java.level>
-    <jcasc.version>1.30</jcasc.version>
+    <jcasc.version>1.35</jcasc.version>
   </properties>
 
   <licenses>
@@ -159,10 +159,9 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.jenkins</groupId>
-      <artifactId>configuration-as-code</artifactId>
+      <groupId>io.jenkins.configuration-as-code</groupId>
+      <artifactId>test-harness</artifactId>
       <version>${jcasc.version}</version>
-      <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
JCasc had to create a new dependency that wasn't a `tests` classifier because maven doesn't allow you to bring dependencies through classifiers.

Upgrading here so that PCT works again,

Tracking:
https://github.com/jenkinsci/bom/pull/164

Note: We'll need a release for PCT please