### PR TITLE
Remove unused dependency cryptacular

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,10 @@ under the License.
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
+        <exclusion>
+          <artifactId>cryptacular</artifactId>
+          <groupId>org.cryptacular</groupId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
This library appears to be unused by the dependency: See https://github.com/pac4j/pac4j/pull/1532

I checked the sources of the older version used here and there's no reference to `cryptacular` in it.

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

