### PR TITLE
Update cryptacular to 1.2.4 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.57</version>
+    <version>3.55</version>
   </parent>
 
   <artifactId>saml</artifactId>
@@ -46,7 +46,7 @@ under the License.
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.176.1</jenkins.version>
     <java.level>8</java.level>
-    <jcasc.version>1.38</jcasc.version>
+    <jcasc.version>1.35</jcasc.version>
   </properties>
 
   <licenses>
@@ -121,7 +121,7 @@ under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.30</version>
+      <version>1.29</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -132,7 +132,7 @@ under the License.
     <dependency>
       <groupId>net.shibboleth.utilities</groupId>
       <artifactId>java-support</artifactId>
-      <version>7.5.1</version>
+      <version>7.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.55</version>
+    <version>3.57</version>
   </parent>
 
   <artifactId>saml</artifactId>
@@ -46,7 +46,7 @@ under the License.
     <changelist>-SNAPSHOT</changelist>
     <jenkins.version>2.176.1</jenkins.version>
     <java.level>8</java.level>
-    <jcasc.version>1.35</jcasc.version>
+    <jcasc.version>1.38</jcasc.version>
   </properties>
 
   <licenses>
@@ -121,7 +121,7 @@ under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
-      <version>1.29</version>
+      <version>1.30</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -132,8 +132,12 @@ under the License.
     <dependency>
       <groupId>net.shibboleth.utilities</groupId>
       <artifactId>java-support</artifactId>
-      <version>7.2.0</version>
+      <version>7.5.1</version>
       <exclusions>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
@@ -165,6 +169,15 @@ under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <dependencyManagement>
+    <dependencies>
+    <dependency>
+      <groupId>org.cryptacular</groupId>
+      <artifactId>cryptacular</artifactId>
+      <version>1.2.4</version>
+    </dependency>
+    </dependencies>
+  </dependencyManagement>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Updating a potential denial of service issue in cryptacular
Updating pac4j to 3.8.2 to pull in changes requires a major rewrite of the plugin

configured  dependency management for cryptaclur to 1.2.4 to resolve CVE-2020-7226. 

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

@kuisathaverat  let me know if you want a Jenkins Issue for this. 