### PR TITLE
docs: documenting that disabling signature is not supported on redirect binding

### DIFF
--- a/doc/CONFIGURE.md
+++ b/doc/CONFIGURE.md
@@ -58,6 +58,7 @@ this key would be recreate when it expires, by default the key is not exposed in
   * **Private Key password** - The password used in the -keypass argument of keytool.
   * **Auth Request Signature** - Enable signature of the Redirect Binding Auth Request,
   If you enable it the encryption and signing key would available in the SP metadata file and URL (JENKINS_URL/securityRealm/metadata).
+  The disable of signing auth request does not work with HTTP redirection binging, it only works for POST binding.
   
 The attribute is sometimes called a claim, and for some IdPs it has a fixed structure, e.g. a URI. So in some documentation,
 you might see the term URI of the claim instead of the name of the attribute.

--- a/doc/TROUBLESHOOTING.md
+++ b/doc/TROUBLESHOOTING.md
@@ -383,3 +383,18 @@ This specific exception if read carefully shows that the intended destination ha
 
 * Check that HTTPS is enabled on Jenkins or Reverse Proxy
 * Make sure that "Jenkins Location" in System Configuration is set to the `https` URL
+
+## It is not possible to disable signature with HTTP redirect binding
+
+Disabling signing setting does not work with redirect binding, 
+It happens since we update the pac4j library on 1.0.2. 
+In 1.9.9 pac4j library `forceSignRedirectBindingAuthnRequest` 
+and `authnRequestSigned` do not work as expected. 
+Indeed it is not possible to change the value of authnRequestSigned, 
+We've to extend the class to overwrite the `isAuthnRequestSigned()` method 
+and add a `setAuthnRequestSigned()` method, 
+but this workaround only works with POST binding. 
+It is not possible to upgrade the library again because it uses a newer version of Sprint 
+and Jenkins Core uses an old one. 
+So the only solution is to stop using pac4j library, 
+and use OpenSAML library directly, but this is a reimplementation of the plugin.

--- a/src/main/webapp/help/forceSignRedirectBindingAuthnRequest.html
+++ b/src/main/webapp/help/forceSignRedirectBindingAuthnRequest.html
@@ -1,6 +1,6 @@
 <div>
     Enable signature of the Auth Request. If you enable it the encryption and signing key would available in the SP metadata file and URL (JENKINS_URL/securityRealm/metadata).
-
+    The disable of signing auth request does not work with HTTP redirection binging, it only works for POST binding.
     <pre>
         &lt;md:SPSSODescriptor AuthnRequestsSigned="true" ...&gt;
     </pre>


### PR DESCRIPTION
See [JENKINS-61917](https://issues.jenkins-ci.org/browse/JENKINS-61917).

documenting that disabling signature is not supported on redirect binding 

