### PR TITLE
org.apache.sanctuario:xmlsec --> 2.1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,6 +176,7 @@ under the License.
         <artifactId>cryptacular</artifactId>
         <version>1.2.4</version>
       </dependency>
+      <!-- TODO: remove when CVE-2019-12400 is resolved -->
       <dependency>
         <groupId>org.apache.santuario</groupId>
         <artifactId>xmlsec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,11 +171,16 @@ under the License.
   </dependencies>
   <dependencyManagement>
     <dependencies>
-    <dependency>
-      <groupId>org.cryptacular</groupId>
-      <artifactId>cryptacular</artifactId>
-      <version>1.2.4</version>
-    </dependency>
+      <dependency>
+        <groupId>org.cryptacular</groupId>
+        <artifactId>cryptacular</artifactId>
+        <version>1.2.4</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.santuario</groupId>
+        <artifactId>xmlsec</artifactId>
+        <version>2.1.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
Resolves [CVE-2019-12400](https://github.com/advisories/GHSA-4q98-wr72-h35w).

Smoke test passed using https://capriza.github.io/samling/samling.html.
