### PR TITLE
[JENKINS-65513] Saml plugin 2.x.x causes deadlock impacting Jenkins performance

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
@@ -25,7 +25,6 @@ import org.opensaml.core.config.InitializationService;
 import org.pac4j.core.context.J2EContext;
 import org.pac4j.core.context.WebContext;
 import org.pac4j.core.http.callback.NoParameterCallbackUrlResolver;
-import org.pac4j.core.http.url.DefaultUrlResolver;
 import org.pac4j.saml.client.SAML2Client;
 import org.pac4j.saml.config.SAML2Configuration;
 
@@ -95,7 +94,7 @@ public abstract class OpenSAMLWrapper<T> {
      * @return a SAML2Client object to interact with the IdP service.
      */
     protected SAML2Client createSAML2Client() {
-        final SAML2Configuration config = new SAML2Configuration();
+        SAML2Configuration config = new SAML2Configuration();
         config.setIdentityProviderMetadataResource(new SamlFileResource(SamlSecurityRealm.getIDPMetadataFilePath()));
         config.setAuthnRequestBindingType(samlPluginConfig.getBinding());
 
@@ -153,7 +152,7 @@ public abstract class OpenSAMLWrapper<T> {
 
         config.setForceServiceProviderMetadataGeneration(true);
         config.setServiceProviderMetadataResource(new SamlFileResource(SamlSecurityRealm.getSPMetadataFilePath()));
-        final SAML2Client saml2Client = new SAML2Client(config);
+        SAML2Client saml2Client = new SAML2Client(config);
         saml2Client.setCallbackUrl(samlPluginConfig.getConsumerServiceUrl());
         saml2Client.setCallbackUrlResolver(new NoParameterCallbackUrlResolver());
         saml2Client.init();

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlProfileWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlProfileWrapper.java
@@ -50,10 +50,11 @@ public class SamlProfileWrapper extends OpenSAMLWrapper<SAML2Profile> {
         SAML2Credentials credentials;
         SAML2Profile saml2Profile;
         try {
-            final SAML2Client client = createSAML2Client();
-            final WebContext context = createWebContext();
+            SAML2Client client = createSAML2Client();
+            WebContext context = createWebContext();
             credentials = client.getCredentials(context);
             saml2Profile = client.getUserProfile(credentials, context);
+            client.destroy();
         } catch (HttpAction|SAMLException e) {
             //if the SAMLResponse is not valid we send the user again to the IdP
             throw new BadCredentialsException(e.getMessage(), e);

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlRedirectActionWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlRedirectActionWrapper.java
@@ -44,10 +44,11 @@ public class SamlRedirectActionWrapper extends OpenSAMLWrapper<RedirectAction> {
         try {
             SAML2Client client = createSAML2Client();
             WebContext context = createWebContext();
-            return client.getRedirectAction(context);
+            RedirectAction redirection = client.getRedirectAction(context);
+            client.destroy();
+            return redirection;
         } catch (HttpAction e) {
             throw new IllegalStateException(e);
         }
-
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSPMetadataWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSPMetadataWrapper.java
@@ -42,10 +42,11 @@ public class SamlSPMetadataWrapper extends OpenSAMLWrapper<HttpResponse> {
      */
     @Override
     protected HttpResponse process() throws IllegalStateException {
-        final SAML2Client client = createSAML2Client();
+        SAML2Client client = createSAML2Client();
         String metadata = "";
         try {
             metadata = client.getServiceProviderMetadataResolver().getMetadata();
+            client.destroy();
         } catch (IOException e) {
            throw new IllegalStateException(e);
         }


### PR DESCRIPTION

See [JENKINS-65513](https://issues.jenkins-ci.org/browse/JENKINS-65513).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->
For some reason now it needs to destroy the SAMLClient to avoid keep a couple of classes running on each creation.

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

