### PR TITLE
fix: [JENKINS-66828] No configurator found for type class org.jenkins.ci.plugins.saml.user.SamlCustomProperty$Attribute

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/user/SamlCustomProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/user/SamlCustomProperty.java
@@ -17,10 +17,10 @@ under the License. */
 package org.jenkinsci.plugins.saml.user;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.*;
 import hudson.model.Descriptor.FormException;
-import hudson.model.User;
-import hudson.model.UserProperty;
-import hudson.model.UserPropertyDescriptor;
+import hudson.security.SecurityRealm;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.saml.SamlSecurityRealm;
@@ -42,7 +42,7 @@ public class SamlCustomProperty extends UserProperty {
      */
     List<Attribute> attributes;
 
-    public static class Attribute{
+    public static class Attribute extends AbstractDescribableImpl<Attribute> {
 
         /**
          * Name of the attribute in the SAML Response.
@@ -93,6 +93,16 @@ public class SamlCustomProperty extends UserProperty {
 
             return Objects.hash(name, displayName, value);
         }
+
+        @Extension
+        public static final class DescriptorImpl extends Descriptor<Attribute> {
+            @NonNull
+            @Override
+            public String getDisplayName() {
+                return "SAML Attribute";
+            }
+        }
+
     }
 
     @DataBoundConstructor
@@ -117,7 +127,7 @@ public class SamlCustomProperty extends UserProperty {
         return this;
     }
 
-    @hudson.Extension
+    @Extension
     public static final class DescriptorImpl extends UserPropertyDescriptor {
         public String getDisplayName() {
             return "Saml Custom Attributes property";


### PR DESCRIPTION

See [JENKINS-66828](https://issues.jenkins-ci.org/browse/JENKINS-66828).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

