### PR TITLE
[JENKINS-67574] `loadUserByUsername` should throw `UserMayOrMayNotExistException2` if the user doesn't exist in Jenkins

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlUserDetailsService.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlUserDetailsService.java
@@ -19,12 +19,12 @@ package org.jenkinsci.plugins.saml;
 
 import hudson.model.User;
 import hudson.security.SecurityRealm;
+import hudson.security.UserMayOrMayNotExistException2;
 import jenkins.model.Jenkins;
 import jenkins.security.LastGrantedAuthoritiesProperty;
 import org.acegisecurity.Authentication;
 import org.acegisecurity.GrantedAuthority;
 import org.acegisecurity.userdetails.UserDetailsService;
-import org.acegisecurity.userdetails.UsernameNotFoundException;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -49,7 +49,8 @@ public class SamlUserDetailsService implements UserDetailsService {
         // try to rebuild authentication details based on data stored in user storage
         User user = User.get(username, false, Collections.emptyMap());
         if (user == null) {
-            throw new UsernameNotFoundException(username);
+            // User logged in to Jenkins, but it could exist in the backend
+            throw new UserMayOrMayNotExistException2(username);
         }
 
         List<GrantedAuthority> authorities = new ArrayList<>();


### PR DESCRIPTION
Since this method doesn't actually check the IDP, it is only relying on
whether the user has already logged in to Jenkins. If not, then it
cannot tell whether the user actually exists or not.

See [JENKINS-67574](https://issues.jenkins-ci.org/browse/JENKINS-67574).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->
I actually don't have a working saml setup so this needs manual testing that the described issue is actually fixed by this patch.

### Submitter checklist

- [X] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

