### PR TITLE
[JENKINS-68471] Prepare SAML for removal of JAXB and Java 11 requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@ under the License.
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>jaxb</artifactId>
+      <version>2.3.6-1</version>
+    </dependency>
+    <dependency>
       <groupId>org.pac4j</groupId>
       <artifactId>pac4j-saml</artifactId>
       <!-- versions 4.x.x require JDK 11 -->
@@ -277,6 +282,12 @@ under the License.
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>6.2.7</version>
+      </dependency>
+      <!-- requireUpperBoundDeps between jaxb and mailer -->
+      <dependency>
+        <groupId>io.jenkins.plugins</groupId>
+        <artifactId>javax-activation-api</artifactId>
+        <version>1.2.0-3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
See [JENKINS-68471](https://issues.jenkins-ci.org/browse/JENKINS-68471). This plugin depends on `org.pac4j:pac4j-saml`, which depends on `org.pac4j:pac4j-saml`, which depends on `org.opensaml:opensaml-security-api`, which depends on `org.apache.santuario:xmlsec`, which depends on JAXB:

```
org.jenkins-ci.plugins:saml:hpi:2.999999-SNAPSHOT
+- org.pac4j:pac4j-saml:jar:3.9.0:compile
|  +- org.opensaml:opensaml-security-api:jar:3.4.3:compile
|  |  +- org.apache.santuario:xmlsec:jar:2.3.0:compile
|  |  |  +- JAXB
```

But when running on Java 9+, JAXB is not included on the classpath by default. The only way for a plugin to have access to JAXB when running on Jenkins 2.164 or later on Java 11 is to declare a plugin-to-plugin dependency on JAXB API plugin (recommended) or to embed JAXB into its `.jpi` file. This PR does the former to ensure that SAML always has access to JAXB on its classpath. CC @kuisathaverat