### PR TITLE
Fix optional property layout of inline help

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/saml/SamlSecurityRealm/config.jelly
@@ -1,5 +1,41 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:d="jelly:define" xmlns:local="local">
+    <d:taglib uri="local">
+        <d:tag name="optionalProperty">
+            <st:documentation>
+                Renders inline an optional single-value nested data-bound property of the current instance,
+                by using a &lt;f:optionalBlock>
+
+                This is useful when your object composes another data-bound object, and when that's optional,
+                where the absence of the value is signified as null (in which case the optionalBlock will be drawn unchecked),
+                and the presence of the value.
+                <st:attribute name="field" use="required">
+                    Used for databinding. TBD.
+                </st:attribute>
+                <st:attribute name="title" use="required">
+                    Human readable text that follows the checkbox.
+
+                    If this field is null, the checkbox degrades to a &lt;f:rowSet>, which provides
+                    a grouping at JSON level but on the UI there's no checkbox (and you always see
+                    the body of it.)
+                </st:attribute>
+                <st:attribute name="help">
+                    If present, the (?) icon will be rendered on the right to show inline help.
+                    See @help for &lt;f:entry>.
+                </st:attribute>
+            </st:documentation>
+            <!--
+              Without @checked, optionalBlock will try to coerce an object to a boolean, which fails,
+              so override @checked manually.
+            -->
+            <f:optionalBlock field="${attrs.field}" title="${attrs.title}" checked="${instance[field]!=null}" help="${attrs.help}">
+                <j:set var="descriptor" value="${app.getDescriptorOrDie(descriptor.getPropertyTypeOrDie(instance,attrs.field).clazz)}" />
+                <j:set var="instance" value="${instance[attrs.field]}"/>
+                <st:include from="${descriptor}" page="${descriptor.configPage}" />
+            </f:optionalBlock>
+        </d:tag>
+    </d:taglib>
+
     <f:property field="idpMetadataConfiguration"/>
     <f:entry title="Display Name Attribute" field="displayNameAttributeName"
              help="/plugin/saml/help/displayNameAttributeName.html">
@@ -39,16 +75,11 @@
     <f:entry title="Logout URL" field="logoutUrl" help="/plugin/saml/help/logoutUrl.html">
         <f:textbox/>
     </f:entry>
-    <f:entry help="/plugin/saml/help/advancedConfiguration.html">
-        <table>
-            <f:optionalProperty title="Advanced Configuration" field="advancedConfiguration"/>
-        </table>
-    </f:entry>
-    <f:entry help="/plugin/saml/help/encryption.html">
-        <table>
-            <f:optionalProperty title="Encryption Configuration" field="encryptionData"/>
-        </table>
-    </f:entry>
+
+    <!-- TODO replace with f:optionalProperty once the plugin relies on a version of Jenkins with https://github.com/jenkinsci/jenkins/pull/6615 -->
+    <local:optionalProperty title="Advanced Configuration" field="advancedConfiguration" help="/plugin/saml/help/advancedConfiguration.html"/>
+    <local:optionalProperty title="Encryption Configuration" field="encryptionData" help="/plugin/saml/help/encryption.html"/>
+
     <f:entry title="Custom Attributes">
         <f:repeatableHeteroProperty field="samlCustomAttributes" hasHeader="true"/>
     </f:entry>


### PR DESCRIPTION
On Jenkins 2.346 and later the new UI layout breaks with the current way this plugin uses optional properties. The inline help  icon is misaligned and it doesn't work when clicking on it.

![image](https://user-images.githubusercontent.com/171459/171116442-45b49dd8-3c23-4cb7-b7e6-c63baba50289.png)

`f:optionalProperty` doesn't support the help attribute, however the
underlying `f:optionalBlock` does. This adds a local copy of
optionalProperty with the help attribute which fixes the layout.



I filed in parallel https://github.com/jenkinsci/jenkins/pull/6615 to fix this at core level and allow removing the local tag copy later.

![Capture d’écran 2022-05-31 à 09 16 04](https://user-images.githubusercontent.com/171459/171116397-afca3c28-ee9a-4b34-82c4-c8ac3cd8c1ad.png)

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

