### PR TITLE
Adapt to Jakarta Mail migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,17 @@ under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>mailer</artifactId>
+      <exclusions>
+        <!--
+          TODO When https://github.com/jenkinsci/jakarta-activation-api-plugin/pull/2 is merged and
+          released, this can be deleted. For now, exclude this dependency from the chain to prevent
+          a require upper bounds conflict with org.pac4j:pac4j-saml:3.9.0.
+        -->
+        <exclusion>
+          <groupId>com.sun.activation</groupId>
+          <artifactId>jakarta.activation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -264,7 +275,7 @@ under the License.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.332.x</artifactId>
-        <version>1478.v81d3dc4f9a_43</version>
+        <version>1500.ve4d05cd32975</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlFormValidation.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlFormValidation.java
@@ -5,8 +5,8 @@ import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-import javax.mail.internet.AddressException;
-import javax.mail.internet.InternetAddress;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.Normalizer;


### PR DESCRIPTION
Recent versions of the Mailer plugin have switched from JavaMail to Jakarta Mail. This plugin consumes this library via Mailer, so it needs to be adapted accordingly. Notably, the update to plugin BOM 1500.ve4d05cd32975 pulls in a new required version of Mailer, which has the Jakarta Mail imports.

CC @kuisathaverat 

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

