### PR TITLE
Use versions from BOM where possible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@ under the License.
     <dependency>
       <groupId>io.jenkins.plugins</groupId>
       <artifactId>jaxb</artifactId>
-      <version>2.3.6-1</version>
     </dependency>
     <dependency>
       <groupId>org.pac4j</groupId>
@@ -215,7 +214,6 @@ under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
-      <version>2.26</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -232,19 +230,16 @@ under the License.
     <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
-      <version>1512.vb_79d418d5fc8</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
-      <version>1512.vb_79d418d5fc8</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -275,7 +270,7 @@ under the License.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.332.x</artifactId>
-        <version>1500.ve4d05cd32975</version>
+        <version>1508.v4b_d09ff0e893</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -295,11 +290,6 @@ under the License.
         <version>6.2.7</version>
       </dependency>
       <!-- requireUpperBoundDeps between jaxb and mailer -->
-      <dependency>
-        <groupId>io.jenkins.plugins</groupId>
-        <artifactId>javax-activation-api</artifactId>
-        <version>1.2.0-3</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -241,12 +241,6 @@ under the License.
       <groupId>io.jenkins.configuration-as-code</groupId>
       <artifactId>test-harness</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -289,7 +283,6 @@ under the License.
         <artifactId>woodstox-core</artifactId>
         <version>6.2.7</version>
       </dependency>
-      <!-- requireUpperBoundDeps between jaxb and mailer -->
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
This is a code cleanup change; there is no urgent need for a release. This change removes hard-coded version numbers where they are not needed because a version is already provided by the BOM. This should make it easier to maintain this plugin by causing the creation of fewer Dependabot PRs.