### PR TITLE
[JENKINS-69898] saml plugin affected by CVE -2022-42003;42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,13 +284,6 @@ under the License.
         <artifactId>xmlsec</artifactId>
         <version>3.0.0</version>
       </dependency>
-      <!--
-      <dependency>
-        <groupId>com.fasterxml.woodstox</groupId>
-        <artifactId>woodstox-core</artifactId>
-        <version>6.2.7</version>
-      </dependency>
-      -->
     </dependencies>
   </dependencyManagement>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@ under the License.
   <properties>
     <revision>4</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361</jenkins.version>
+    <jenkins.version>2.361.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.compatibleSinceVersion>3.343.vb_63a_6c3df23c</hpi.compatibleSinceVersion>
   </properties>
@@ -193,6 +193,14 @@ under the License.
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.woodstox</groupId>
+          <artifactId>woodstox-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -207,6 +215,11 @@ under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>jackson2-api</artifactId>
+      <version>2.13.4.20221013-295.v8e29ea_354141</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -271,11 +284,13 @@ under the License.
         <artifactId>xmlsec</artifactId>
         <version>3.0.0</version>
       </dependency>
+      <!--
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
         <version>6.2.7</version>
       </dependency>
+      -->
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
See [JENKINS-69898](https://issues.jenkins-ci.org/browse/JENKINS-69898).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

I have added the Jackson API plugin dependency and exclude the Jackson library from the pac4j

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

