### PR TITLE
fix: disable external entities resolution

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
@@ -135,9 +135,9 @@ public class IdpMetadataConfiguration extends AbstractDescribableImpl<IdpMetadat
             URLConnection urlConnection = ProxyConfiguration.open(new URL(url));
             try (InputStream in = urlConnection.getInputStream()) {
                 TransformerFactory tf = TransformerFactory.newInstance();
-                tf.setFeature(XMLConstants.ACCESS_EXTERNAL_DTD, false);
-                tf.setFeature(XMLConstants.ACCESS_EXTERNAL_SCHEMA, false);
-
+                tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                tf.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
                 tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 Transformer transformer = tf.newTransformer();
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");

--- a/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
@@ -135,6 +135,9 @@ public class IdpMetadataConfiguration extends AbstractDescribableImpl<IdpMetadat
             URLConnection urlConnection = ProxyConfiguration.open(new URL(url));
             try (InputStream in = urlConnection.getInputStream()) {
                 TransformerFactory tf = TransformerFactory.newInstance();
+                tf.setFeature(XMLConstants.ACCESS_EXTERNAL_DTD, false);
+                tf.setFeature(XMLConstants.ACCESS_EXTERNAL_SCHEMA, false);
+
                 tf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
                 Transformer transformer = tf.newTransformer();
                 transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");


### PR DESCRIPTION
Resolving XML external entity in user-controlled data

https://github.com/jenkinsci/saml-plugin/security/code-scanning/50

In the case the IdP metadata is configured to be downloaded from a trusted URL, the plugin resolves the external entities, to improve the security this PR disabled the external entities resolution.