### PR TITLE
[JENKINS-69930] NullPointerException from getUseDiskCache in SAML plugin

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
@@ -70,7 +70,7 @@ public class SamlAdvancedConfiguration extends AbstractDescribableImpl<SamlAdvan
     }
 
     public Boolean getUseDiskCache() {
-        return useDiskCache;
+        return useDiskCache != null ? useDiskCache : false;
     }
 
     @DataBoundSetter


### PR DESCRIPTION
See [JENKINS-69930](https://issues.jenkins-ci.org/browse/JENKINS-69930).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [X] JIRA issue is well described
- [X] Appropriate autotests or explanation to why this change has no tests

