### PR TITLE
Stop bundling unnecessary libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,10 @@ under the License.
 
   <dependencies>
     <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
     </dependency>
@@ -137,7 +141,7 @@ under the License.
         </exclusion>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
-          <artifactId>bcprov-jdk15on</artifactId>
+          <artifactId>bcprov-jdk18on</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.dom4j</groupId>
@@ -202,6 +206,10 @@ under the License.
         <exclusion>
           <groupId>com.fasterxml.woodstox</groupId>
           <artifactId>woodstox-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
Removes `bcprov-jdk18on-1.71.jar` and `commons-lang3-3.11.jar` from the `WEB-INF/lib` directory of the HPI file in favor of the corresponding library plugins. This is the preferred mechanism for dynamic linking in the Jenkins plugin ecosystem. CC @kuisathaverat 