### PR TITLE
Upgrade HtmlUnit to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@ under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.65</version>
+    <version>4.67</version>
     <relativePath />
   </parent>
 
@@ -46,7 +46,7 @@ under the License.
   <properties>
     <revision>4</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.361.4</jenkins.version>
+    <jenkins.version>2.387.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.compatibleSinceVersion>3.343.vb_63a_6c3df23c</hpi.compatibleSinceVersion>
   </properties>
@@ -141,7 +141,19 @@ under the License.
         </exclusion>
         <exclusion>
           <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-jdk15on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
           <artifactId>bcprov-jdk18on</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcutil-jdk15on</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.dom4j</groupId>
@@ -267,8 +279,8 @@ under the License.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.361.x</artifactId>
-        <version>2102.v854b_fec19c92</version>
+        <artifactId>bom-2.387.x</artifactId>
+        <version>2179.v0884e842b_859</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/test/java/org/jenkinsci/plugins/saml/LiveTest.java
+++ b/src/test/java/org/jenkinsci/plugins/saml/LiveTest.java
@@ -16,10 +16,10 @@
 
 package org.jenkinsci.plugins.saml;
 
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlPasswordInput;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import org.htmlunit.Page;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlPasswordInput;
+import org.htmlunit.html.HtmlTextInput;
 import hudson.util.Secret;
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
Changes in the test framework cause the need for the baseline to be updated to 2.387 to pick up test JARs with the updated HtmlUnit imports.

Closes #348