### PR TITLE
[JENKINS-73316] Require Java 17 and 2.475; adapt test suite to EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,12 @@ under the License.
   <properties>
     <revision>4</revision>
     <changelist>999999-SNAPSHOT</changelist>
-    <jenkins.version>2.401.3</jenkins.version>
+    <jenkins.version>2.475</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.compatibleSinceVersion>3.343.vb_63a_6c3df23c</hpi.compatibleSinceVersion>
+    <!-- TODO JENKINS-73339 until in parent POM -->
+    <jenkins-test-harness.version>2254.vcff7a_d4969e5</jenkins-test-harness.version>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <licenses>
@@ -295,10 +298,16 @@ under the License.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.401.x</artifactId>
-        <version>2745.vc7b_fe4c876fa_</version>
+        <artifactId>bom-2.462.x</artifactId>
+        <version>3307.v2769886db_63b_</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- TODO JENKINS-73339 until in parent POM, work around https://github.com/jenkinsci/plugin-pom/issues/936 -->
+      <dependency>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
+        <version>5.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.santuario</groupId>

--- a/src/test/java/org/jenkinsci/plugins/saml/OpenSamlWrapperTest.java
+++ b/src/test/java/org/jenkinsci/plugins/saml/OpenSamlWrapperTest.java
@@ -23,10 +23,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.HttpResponse;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.mockito.Mockito;
 
-import javax.servlet.ServletException;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -60,7 +60,7 @@ public class OpenSamlWrapperTest {
         jenkinsRule.jenkins.setSecurityRealm(samlSecurity);
         SamlSPMetadataWrapper samlSPMetadataWrapper = new SamlSPMetadataWrapper(samlSecurity.getSamlPluginConfig(), null, null);
         HttpResponse process = samlSPMetadataWrapper.get();
-        StaplerResponse mockResponse = Mockito.mock(StaplerResponse.class);
+        StaplerResponse2 mockResponse = Mockito.mock(StaplerResponse2.class);
         StringWriter stringWriter = new StringWriter();
         when(mockResponse.getWriter()).thenReturn(new PrintWriter(stringWriter));
         process.generateResponse(null, mockResponse, null);
@@ -89,7 +89,7 @@ public class OpenSamlWrapperTest {
         jenkinsRule.jenkins.setSecurityRealm(samlSecurity);
         SamlSPMetadataWrapper samlSPMetadataWrapper = new SamlSPMetadataWrapper(samlSecurity.getSamlPluginConfig(), null, null);
         HttpResponse process = samlSPMetadataWrapper.get();
-        StaplerResponse mockResponse = Mockito.mock(StaplerResponse.class);
+        StaplerResponse2 mockResponse = Mockito.mock(StaplerResponse2.class);
         StringWriter stringWriter = new StringWriter();
         when(mockResponse.getWriter()).thenReturn(new PrintWriter(stringWriter));
         process.generateResponse(null, mockResponse, null);


### PR DESCRIPTION
See [JENKINS-73316](https://issues.jenkins.io/browse/JENKINS-73316). Allow this plugin's test suite to be exercised regularly in Plugin Compatibility Tester (PCT) in https://github.com/jenkinsci/bom by requiring Java 17 or newer and Jenkins 2.475 (released today) or newer.

This PR goes against the usual advice from https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ by requiring a weekly release. The advantage is that this will allow plugin compatibility testing (PCT). The disadvantage is that new features and bug fixes can't be released to LTS users for another few months.

The choice is up to the maintainer as to whether or not to accept this PR. If this PR is rejected, we will stop testing this plugin in PCT.