### PR TITLE
Avoid Apache Commons IO utility methods when writing config files to `JENKINS_HOME` to fix `AccessDeniedException` in some cases

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
@@ -8,6 +8,8 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -116,7 +118,7 @@ public class IdpMetadataConfiguration extends AbstractDescribableImpl<IdpMetadat
     public void createIdPMetadataFile() throws IOException {
         try {
             if (StringUtils.isNotBlank(xml)) {
-                FileUtils.writeStringToFile(new File(SamlSecurityRealm.getIDPMetadataFilePath()), xml,
+                Files.write(new File(SamlSecurityRealm.getIDPMetadataFilePath()).toPath(), List.of(xml),
                                             StandardCharsets.UTF_8);
             } else {
                 updateIdPMetadata();
@@ -140,7 +142,7 @@ public class IdpMetadataConfiguration extends AbstractDescribableImpl<IdpMetadat
 
                 FormValidation validation = new SamlValidateIdPMetadata(idpXml).get();
                 if (FormValidation.Kind.OK == validation.kind) {
-                    FileUtils.writeStringToFile(new File(SamlSecurityRealm.getIDPMetadataFilePath()), idpXml,
+                    Files.write(new File(SamlSecurityRealm.getIDPMetadataFilePath()).toPath(), List.of(idpXml),
                                                 StandardCharsets.UTF_8);
                 } else {
                     throw new IllegalArgumentException(validation.getMessage());

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceCache.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceCache.java
@@ -33,6 +33,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -152,7 +153,7 @@ class SamlFileResourceCache implements WritableResource {
 
     private void save(@NonNull String fileName, @NonNull String data) throws IOException {
         if(isNew(fileName, data)) {
-            FileUtils.writeByteArrayToFile(new File(fileName), data.getBytes("UTF-8"));
+            Files.write(new File(fileName).toPath(), data.getBytes("UTF-8"));
             cache.put(fileName, data);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceDisk.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceDisk.java
@@ -27,6 +27,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.NotImplementedException;
 import org.pac4j.core.exception.TechnicalException;
@@ -47,7 +48,7 @@ class SamlFileResourceDisk implements WritableResource {
     public SamlFileResourceDisk(@NonNull String fileName, @NonNull String data) {
         this.fileName = fileName;
         try {
-            FileUtils.writeByteArrayToFile(getFile(), data.getBytes(StandardCharsets.UTF_8));
+            Files.write(getFile().toPath(), data.getBytes(StandardCharsets.UTF_8));
         } catch (UnsupportedEncodingException e) {
             throw new TechnicalException("Could not get string bytes.", e);
         } catch (java.io.IOException e) {
@@ -129,6 +130,6 @@ class SamlFileResourceDisk implements WritableResource {
     @NonNull
     @Override
     public OutputStream getOutputStream() throws IOException {
-        return FileUtils.openOutputStream(getFile());
+        return Files.newOutputStream(getFile().toPath());
     }
 }


### PR DESCRIPTION
(I can file a Jira ticket if needed)

I recently investigated an issue reported by a user where Jenkins was working totally normally, but when they tried to change their security realm to SAML, they were unable to save the change. The issue seemed to be that they had JENKINS_HOME hard linked to an NFS mount point like `/my-mount`, and this broke the logic in the Apache Common IO utility methods that check for the existence of the file and create parent directories if needed. Here is the relevant part of the stack trace:

```
java.nio.file.AccessDeniedException: /my-mount
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:389)
	at java.base/java.nio.file.Files.createDirectory(Files.java:690)
	at java.base/java.nio.file.Files.createAndCheckIsDirectory(Files.java:797)
	at java.base/java.nio.file.Files.createDirectories(Files.java:783)
	at org.apache.commons.io.file.PathUtils.createParentDirectories(PathUtils.java:401)
	at org.apache.commons.io.file.PathUtils.newOutputStream(PathUtils.java:1212)
	at org.apache.commons.io.file.PathUtils.newOutputStream(PathUtils.java:1207)
	at org.apache.commons.io.FileUtils.newOutputStream(FileUtils.java:2476)
	at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3509)
	at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3494)
	at org.jenkinsci.plugins.saml.IdpMetadataConfiguration.createIdPMetadataFile(IdpMetadataConfiguration.java:119)
```

Interactive testing in the script console showed that the `FileUtils.writeStringToFile` method really was uniquely causing the issue (I also checked whether the use of `getAbsolutePath` in the config file path getter methods was a problem), and `Files.write` worked fine for the same files.

In this plugin, we always use these methods to write files that are direct children of `JENKINS_HOME`, so there is no need to 
 check for and create parent directories since we can assume that `JENKINS_HOME` exists, so this PR just switches to using `Files.write` in all of the relevant cases.

I did not find a way to reproduce the same `AccessDeniesException` reported by the user in a test to be able to create a regression test. The logic seems to be covered in at least basic ways by the existing tests though.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

