### PR TITLE
Force velocity-engine-core to 2.4 in dptManagement to not bring a version depending on commons-io with CVE, even if not reachable at least this will make scanner to stop reporting non existing problem...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@ under the License.
         <artifactId>xmlsec</artifactId>
         <version>4.0.3</version>
       </dependency>
+      <!-- TODO remove when update to pac4j 6.1-->
       <dependency>
         <groupId>org.apache.velocity</groupId>
         <artifactId>velocity-engine-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,11 @@ under the License.
         <artifactId>xmlsec</artifactId>
         <version>4.0.3</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.velocity</groupId>
+        <artifactId>velocity-engine-core</artifactId>
+        <version>2.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
Some dependency scanning tool are complaining about this plugin affected by https://nvd.nist.gov/vuln/detail/CVE-2024-47554
Because there is a transitive dependency to commons-io via velocity-core-engine 2.3 and even if commons-io is shaded and the affected class is not in the shaded jar...
So to make those "smart" scanner stop complaining an upgrade to velocity 2.4 will prevent to see transitive dependency to commons-io.

