### PR TITLE
Remove not anymore needed exclusions which breaks PCT test from 2.489, test with mvn clean install -Djenkins.version=2.489

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,16 +251,6 @@ under the License.
       <artifactId>testcontainers</artifactId>
       <version>1.20.4</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-compress</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
   <dependencyManagement>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

