### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/saml-plugin-developers


### PR DESCRIPTION
Introduce a CODEOWNERS file to define code ownership for the repository.