### PR TITLE
[JENKINS-75917] Restore session recreation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -293,6 +293,7 @@ public class SamlSecurityRealm extends SecurityRealm {
     public HttpResponse doFinishLogin(final StaplerRequest2 request, final StaplerResponse2 response) {
         LOG.finer("SamlSecurityRealm.doFinishLogin called");
         String redirectUrl = null;
+        recreateSession(request);
         logSamlResponse(request);
 
         boolean saveUser = false;


### PR DESCRIPTION
See [JENKINS-75917](https://issues.jenkins-ci.org/browse/JENKINS-75917).

Somehow I determined this wasn't necessary as it would happen anyway, but apparently not. Maybe because it was too late? Unsure, but I was able to reproduce the problem locally, and it went away with this line restored.

### Submitter checklist

- [x] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

