### PR TITLE
chore: bump Jenkins Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@ under the License.
   <packaging>hpi</packaging>
   <name>SAML Plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-
   <licenses>
     <license>
       <name>Apache 2.0 License</name>
@@ -70,12 +69,13 @@ under the License.
     <revision>4</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+    <jenkins.baseline>2.504</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <hpi.compatibleSinceVersion>3.343.vb_63a_6c3df23c</hpi.compatibleSinceVersion>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
This pull request updates the `pom.xml` file to align with a newer Jenkins baseline and versioning scheme.

### Dependency Updates:
* Replaced the `jenkins.version` property with a new `jenkins.baseline` property set to `2.504`, and updated `jenkins.version` to use `${jenkins.baseline}.1` for consistency with the new baseline. (`[pom.xmlL49-R52](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L49-R52)`)