### PR TITLE
When loading SamlSecurityRealm instance, the IDP metadata file may need to be created when using URL and not inline XML.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -223,8 +223,7 @@ public class SamlSecurityRealm extends SecurityRealm {
     @SuppressWarnings("unused")
     public Object readResolve() {
         File idpMetadataFile = new File(getIDPMetadataFilePath());
-        if (!idpMetadataFile.exists()
-                && idpMetadataConfiguration != null) {
+        if (!idpMetadataFile.exists() && idpMetadataConfiguration != null) {
             try {
                 idpMetadataConfiguration.createIdPMetadataFile();
             } catch (IOException e) {


### PR DESCRIPTION
Otherwise, it will eventually get created whenever `UpdateMetadataFromURLPeriodicWork` runs, but only after its initial delay.

To give slightly more context, I hit this bug in CloudBees CI in a context where the SAML security realm gets created through deserialization. `readResolve` gets called, but as the configuration is provided through an URL and not through inline XML, and this is the first time the controller starts, the IDP metadata file doesn't exist, and there is a time window where login will fail under `commenceLogin`, complaining that the IDP metadata file is missing.

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

