### PR TITLE
Remove joda time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,11 +98,6 @@ under the License.
         <artifactId>xmlsec</artifactId>
         <version>4.0.4</version>
       </dependency>
-      <dependency>
-        <groupId>org.apache.santuario</groupId>
-        <artifactId>xmlsec</artifactId>
-        <version>4.0.4</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -118,10 +118,6 @@ under the License.
       <artifactId>commons-text-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>joda-time-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
     </dependency>
@@ -197,10 +193,6 @@ under the License.
         <exclusion>
           <groupId>commons-text</groupId>
           <artifactId>commons-text</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>joda-time</groupId>
-          <artifactId>joda-time</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
plugin dependended incorrectly on joda-time api plugin (the dependency in pac4j was removed in https://github.com/pac4j/pac4j/commit/b968b45bfd083b425ab0f5c67d60a58ea5cda6b7)
Additionally there was a duplicate depenedency entry in dependencyManagement causing build warnings.

<!-- Comment: 
If the issue is not fully described in the ticket, add more information here (justification, pull request links, etc.).
Every PR should have a JIRA issue.
-->

### Submitter checklist

- [ ] JIRA issue is well described
- [ ] Appropriate autotests or explanation to why this change has no tests

