### PR TITLE
Migrate Commons Lang from 2 to 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@ under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.27</version>
+    <version>6.2116.v7501b_67dc517</version>
     <relativePath />
   </parent>
 
@@ -76,6 +76,7 @@ under the License.
     <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
     <hpi.compatibleSinceVersion>3.343.vb_63a_6c3df23c</hpi.compatibleSinceVersion>
     <spotless.check.skip>false</spotless.check.skip>
+    <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/org/jenkinsci/plugins/saml/BundleKeyStore.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/BundleKeyStore.java
@@ -27,7 +27,7 @@ import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x500.X500Name;

--- a/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/IdpMetadataConfiguration.java
@@ -29,7 +29,7 @@ import jenkins.model.Jenkins;
 import jenkins.util.xml.XMLUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;

--- a/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/OpenSAMLWrapper.java
@@ -22,7 +22,7 @@ import static java.util.logging.Level.SEVERE;
 
 import java.util.Arrays;
 import java.util.logging.Logger;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
 import org.opensaml.core.config.InitializationException;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlAdvancedConfiguration.java
@@ -27,7 +27,7 @@ import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.interceptor.RequirePOST;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlEncryptionData.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlEncryptionData.java
@@ -50,7 +50,7 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.Enumeration;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.interceptor.RequirePOST;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlFileResource.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlFileResource.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;
 

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceCache.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceCache.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.pac4j.core.exception.TechnicalException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceDisk.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlFileResourceDisk.java
@@ -29,7 +29,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.pac4j.core.exception.TechnicalException;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlFormValidation.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlFormValidation.java
@@ -8,7 +8,7 @@ import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlPluginConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlPluginConfig.java
@@ -23,7 +23,7 @@ import static org.jenkinsci.plugins.saml.SamlSecurityRealm.DEFAULT_USERNAME_CASE
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * contains all the Jenkins SAML Plugin settings

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -192,8 +192,8 @@ public class SamlSecurityRealm extends SecurityRealm {
         super();
         this.idpMetadataConfiguration = idpMetadataConfiguration;
         this.usernameAttributeName = hudson.Util.fixEmptyAndTrim(usernameAttributeName);
-        this.usernameCaseConversion = StringUtils.defaultIfBlank(
-                usernameCaseConversion, DEFAULT_USERNAME_CASE_CONVERSION);
+        this.usernameCaseConversion =
+                StringUtils.defaultIfBlank(usernameCaseConversion, DEFAULT_USERNAME_CASE_CONVERSION);
         this.logoutUrl = hudson.Util.fixEmptyAndTrim(logoutUrl);
         this.displayNameAttributeName = DEFAULT_DISPLAY_NAME_ATTRIBUTE_NAME;
         this.groupsAttributeName = DEFAULT_GROUPS_ATTRIBUTE_NAME;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import jenkins.security.SecurityListener;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.saml.conf.Attribute;
 import org.jenkinsci.plugins.saml.conf.AttributeEntry;
 import org.jenkinsci.plugins.saml.user.SamlCustomProperty;
@@ -192,7 +192,7 @@ public class SamlSecurityRealm extends SecurityRealm {
         super();
         this.idpMetadataConfiguration = idpMetadataConfiguration;
         this.usernameAttributeName = hudson.Util.fixEmptyAndTrim(usernameAttributeName);
-        this.usernameCaseConversion = org.apache.commons.lang.StringUtils.defaultIfBlank(
+        this.usernameCaseConversion = org.apache.commons.lang3.StringUtils.defaultIfBlank(
                 usernameCaseConversion, DEFAULT_USERNAME_CASE_CONVERSION);
         this.logoutUrl = hudson.Util.fixEmptyAndTrim(logoutUrl);
         this.displayNameAttributeName = DEFAULT_DISPLAY_NAME_ATTRIBUTE_NAME;
@@ -207,7 +207,7 @@ public class SamlSecurityRealm extends SecurityRealm {
         if (maximumAuthenticationLifetime != null && maximumAuthenticationLifetime > 0) {
             this.maximumAuthenticationLifetime = maximumAuthenticationLifetime;
         }
-        if (org.apache.commons.lang.StringUtils.isNotBlank(emailAttributeName)) {
+        if (org.apache.commons.lang3.StringUtils.isNotBlank(emailAttributeName)) {
             this.emailAttributeName = hudson.Util.fixEmptyAndTrim(emailAttributeName);
         }
         this.advancedConfiguration = advancedConfiguration;

--- a/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/SamlSecurityRealm.java
@@ -192,7 +192,7 @@ public class SamlSecurityRealm extends SecurityRealm {
         super();
         this.idpMetadataConfiguration = idpMetadataConfiguration;
         this.usernameAttributeName = hudson.Util.fixEmptyAndTrim(usernameAttributeName);
-        this.usernameCaseConversion = org.apache.commons.lang3.StringUtils.defaultIfBlank(
+        this.usernameCaseConversion = StringUtils.defaultIfBlank(
                 usernameCaseConversion, DEFAULT_USERNAME_CASE_CONVERSION);
         this.logoutUrl = hudson.Util.fixEmptyAndTrim(logoutUrl);
         this.displayNameAttributeName = DEFAULT_DISPLAY_NAME_ATTRIBUTE_NAME;
@@ -207,7 +207,7 @@ public class SamlSecurityRealm extends SecurityRealm {
         if (maximumAuthenticationLifetime != null && maximumAuthenticationLifetime > 0) {
             this.maximumAuthenticationLifetime = maximumAuthenticationLifetime;
         }
-        if (org.apache.commons.lang3.StringUtils.isNotBlank(emailAttributeName)) {
+        if (StringUtils.isNotBlank(emailAttributeName)) {
             this.emailAttributeName = hudson.Util.fixEmptyAndTrim(emailAttributeName);
         }
         this.advancedConfiguration = advancedConfiguration;

--- a/src/main/java/org/jenkinsci/plugins/saml/UpdateMetadataFromURLPeriodicWork.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/UpdateMetadataFromURLPeriodicWork.java
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * <p>This periodic work update the IdP Metadata File, the periodicof the execution is defined on the SAML Plugin configuration.</p>

--- a/src/main/java/org/jenkinsci/plugins/saml/user/LoginDetailsProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/saml/user/LoginDetailsProperty.java
@@ -27,7 +27,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
-import org.apache.commons.lang.time.FastDateFormat;
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.jenkinsci.plugins.saml.SamlSecurityRealm;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest2;

--- a/src/test/java/org/jenkinsci/plugins/saml/SamlSecurityRealmTest.java
+++ b/src/test/java/org/jenkinsci/plugins/saml/SamlSecurityRealmTest.java
@@ -47,7 +47,7 @@ import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
In preparation for https://github.com/jenkinsci/jenkins/pull/26105 remove lang2 usages. As this plugin already has lang3 dependency declared https://github.com/jenkinsci/saml-plugin/blob/293ffb525a672aba90234ab8e578b913f4812855/pom.xml#L112-L115
migrating the import paths to lang3.

Created from https://github.com/jenkinsci/saml-plugin/pull/763 resolving conflict and a minor issue.

**Testing**

* compiles after putting lang2 ban, and compiled against local jenkins without the lang2 - `mvn clean compile -Djenkins.version=2.574-SNAPSHOT`