### PR TITLE
ignore pac4j Dependabot bumps pending upstream fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
           - "org.pac4j*"
           - "pac4j-*"
     ignore:
-      # Ignore pac4j upgrades pending fix for test classes shipped in production JAR (BEE-73323)
+      # Ignore pac4j pending https://groups.google.com/g/pac4j-dev/c/PgWtjlRwP4E
       - dependency-name: "org.pac4j:*"
   - package-ecosystem: "github-actions"
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
         patterns:
           - "org.pac4j*"
           - "pac4j-*"
+    ignore:
+      # Ignore pac4j upgrades pending fix for test classes shipped in production JAR (BEE-73323)
+      - dependency-name: "org.pac4j:*"
   - package-ecosystem: "github-actions"
     directory: /
     schedule:


### PR DESCRIPTION
## What

Adds a Dependabot ignore rule for all `org.pac4j:*` dependencies to prevent
automated bumps to pac4j 6.5.x and above.

compliments  https://github.com/jenkinsci/saml-plugin/pull/767#pullrequestreview-4663884933

## Why

pac4j commit [a0fbdd610b](https://github.com/pac4j/pac4j/actions/runs/23905698775) ("rework build", April 2026) moved 12 test utility
classes  from `src/test/java` into `src/main/java`, causing them to ship inside
the production 

saml-plugin is currently on pac4j 6.4.1 which predates this change and is
not affected. The ignore rule prevents Dependabot from bumping to 6.5.0+
until the upstream fix is in place.