### PR TITLE
re-enable pac4j Dependabot bumps once upstream fix ships

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,6 @@ updates:
         patterns:
           - "org.pac4j*"
           - "pac4j-*"
-    ignore:
-      # Ignore pac4j pending https://groups.google.com/g/pac4j-dev/c/PgWtjlRwP4E
-      - dependency-name: "org.pac4j:*"
   - package-ecosystem: "github-actions"
     directory: /
     schedule:


### PR DESCRIPTION
## DO NOT MERGE until upstream pac4j fix is confirmed shipped

This is a reminder PR. It reverts the ignore rule added in #781 which
suppressed Dependabot bumps for `org.pac4j:*` pending an upstream fix.

## Why this PR exists

PR #781 added a Dependabot ignore rule to prevent automated bumps to
pac4j 6.5.0+ while pac4j commit [a0fbdd610b](https://github.com/pac4j/pac4j/actions/runs/23905698775) shipped test infrastructure
classes  inside the production pac4j-core JAR.


## When to merge this PR

Once the upstream pac4j fix is released and saml-plugin has been updated
to a version of pac4j that includes the fix, merge this PR to re-enable
Dependabot pac4j bumps.